### PR TITLE
Update how-to-train.md

### DIFF
--- a/how-to-train.md
+++ b/how-to-train.md
@@ -170,7 +170,7 @@ class EsperantoDataset(Dataset):
         src_files = Path("./data/").glob("*-eval.txt") if evaluate else Path("./data/").glob("*-train.txt")
         for src_file in src_files:
             print("🔥", src_file)
-            lines = src_file.open(encoding="utf-8").read().splitlines()
+	    lines = src_file.read_text(encoding="utf-8").splitlines()
             self.examples += [x.ids for x in tokenizer.encode_batch(lines)]
 
     def __len__(self):


### PR DESCRIPTION
`.open()` files should be closed. As currently written, the opened file handles were never closed - which might cause issues when the same file is used around different processes at the same time. This proposed change uses pathlib's built-in `read_text` which opens the file, reads contents, and closes it immediately in one go.