### PR TITLE
Fixing indentation error

### DIFF
--- a/how-to-train.md
+++ b/how-to-train.md
@@ -180,8 +180,8 @@ class EsperantoDataset(Dataset):
         src_files = Path("./data/").glob("*-eval.txt") if evaluate else Path("./data/").glob("*-train.txt")
         for src_file in src_files:
             print("🔥", src_file)
-        lines = src_file.read_text(encoding="utf-8").splitlines()
-        self.examples += [x.ids for x in tokenizer.encode_batch(lines)]
+            lines = src_file.read_text(encoding="utf-8").splitlines()
+            self.examples += [x.ids for x in tokenizer.encode_batch(lines)]
 
     def __len__(self):
         return len(self.examples)


### PR DESCRIPTION
The indentation issue fixed by #47 introduced a new error. With the new code only the last file in `src_files` would be read and tokenized instead of every file in the corpus data folder.