### PR TITLE
01_how_to_train.ipynb: Fix TypeError

### DIFF
--- a/notebooks/01_how_to_train.ipynb
+++ b/notebooks/01_how_to_train.ipynb
@@ -1201,6 +1201,7 @@
         "    per_gpu_train_batch_size=64,\n",
         "    save_steps=10_000,\n",
         "    save_total_limit=2,\n",
+        "    prediction_loss_only=True,\n",
         ")\n",
         "\n",
         "trainer = Trainer(\n",
@@ -1208,7 +1209,6 @@
         "    args=training_args,\n",
         "    data_collator=data_collator,\n",
         "    train_dataset=dataset,\n",
-        "    prediction_loss_only=True,\n",
         ")"
       ],
       "execution_count": 0,


### PR DESCRIPTION
`prediction_loss_only` should go to `TrainingArguments`