### PR TITLE
Fixed broken link in 01_how_to_train.ipynb

### DIFF
--- a/notebooks/01_how_to_train.ipynb
+++ b/notebooks/01_how_to_train.ipynb
@@ -901,7 +901,7 @@
       "source": [
         "## 3. Train a language model from scratch\n",
         "\n",
-        "**Update:** This section follows along the [`run_language_modeling.py`](https://github.com/huggingface/transformers/blob/master/examples/language-modeling/run_language_modeling.py) script, using our new [`Trainer`](https://github.com/huggingface/transformers/blob/master/src/transformers/trainer.py) directly. Feel free to pick the approach you like best.\n",
+        "**Update:** This section follows along the [`run_language_modeling.py`](https://github.com/huggingface/transformers/blob/master/examples/legacy/run_language_modeling.py) script, using our new [`Trainer`](https://github.com/huggingface/transformers/blob/master/src/transformers/trainer.py) directly. Feel free to pick the approach you like best.\n",
         "\n",
         "> We’ll train a RoBERTa-like model, which is a BERT-like with a couple of changes (check the [documentation](https://huggingface.co/transformers/model_doc/roberta.html) for more details).\n",
         "\n",


### PR DESCRIPTION
Fixing broken link to [run_language_modeling.py](https://github.com/huggingface/transformers/blob/master/examples/legacy/run_language_modeling.py)