### PR TITLE
Update PyTorch/XLA blog post wheel version

### DIFF
--- a/notebooks/13_pytorch_xla.ipynb
+++ b/notebooks/13_pytorch_xla.ipynb
@@ -49,7 +49,7 @@
         "  torch==1.7.0 \\\n",
         "  cloud-tpu-client==0.10 \\\n",
         "  datasets==1.2.1 \\\n",
-        "  https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.7-cp36-cp36m-linux_x86_64.whl\n",
+        "  https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.7-cp37-cp37m-linux_x86_64.whl\n",
         "!git clone -b v4.2.2 https://github.com/huggingface/transformers"
       ],
       "execution_count": null,


### PR DESCRIPTION
Colab updated their python runtime from 3.6 to 3.7 (`torch_xla` isn't on pypi yet as it's not manylinux compatible).

cc: @LysandreJik 