### PR TITLE
[ray-tune] Update Ray Tune blog post examples to be runnable

### DIFF
--- a/ray-tune.md
+++ b/ray-tune.md
@@ -99,7 +99,7 @@ To demonstrate this new [Hugging Face](https://github.com/huggingface/transforme
 
 To run this example, please first run:
 
-**`pip install "ray[tune]" transformers datasets scipy sklearn`**
+**`pip install "ray[tune]" transformers datasets scipy sklearn torch`**
 
 Simply plug in one of Ray’s standard tuning algorithms by just adding a few lines of code.
 


### PR DESCRIPTION
The example code in this blog post will result in errors due to a combination of breaking API changes and missing dependencies. This change allows the user to run the code successfully on a clean environment (with or without GPUs).

**Changes:**

1. Update pip installation packages to include all required dependencies.
2. Replace deprecated `evaluate_during_training` parameter with `evaluation_strategy`.
3. Remove  `n_jobs` which is not supported in the Ray integration.
4. Add `metric`/`mode` to `search_alg`/`scheduler`. **Note:** We can also update `run_hp_search_ray` to pass these directly into `tune.run` as an optimization.
5. Refresh modified links.