### PR TITLE
Indicating a higher version of `datasets`

### DIFF
--- a/fine-tune-wav2vec2-english.md
+++ b/fine-tune-wav2vec2-english.md
@@ -76,7 +76,7 @@ the `jiwer` to evaluate our fine-tuned model using the [word error rate
 (WER)](https://huggingface.co/metrics/wer) metric \\({}^1\\).
 
 ```bash
-!pip install datasets==1.4.1
+!pip install datasets>=1.5.0
 !pip install transformers==4.4.0
 !pip install soundfile
 !pip install jiwer


### PR DESCRIPTION
A problem with version 1.4.1 of `datasets` caused this tutorial to fail, since the transcripts for the train set of TIMIT were all labeled erroneously as "Would such an act of refusal be useful?"

I've tested with 1.11, but per https://github.com/huggingface/datasets/issues/2879#issuecomment-915061528 the issue was fixed in 1.5.0.