### PR TITLE
Fix links: rename master to main

### DIFF
--- a/1b-sentence-embeddings.md
+++ b/1b-sentence-embeddings.md
@@ -8,7 +8,7 @@ title: "Train a Sentence Embedding Model with 1B Training Pairs"
 
 <div class="blog-metadata">
     <small>Published September 1, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/1b-sentence-embeddings.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/1b-sentence-embeddings.md">
         Update on GitHub
     </a>
 </div>

--- a/accelerate-library.md
+++ b/accelerate-library.md
@@ -9,7 +9,7 @@ thumbnail: /blog/assets/20_accelerate_library/accelerate_diff.png
 
 <div class="blog-metadata">
     <small>Published April 16, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/accelerate-library.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/accelerate-library.md">
         Update on GitHub
     </a>
 </div>

--- a/accelerated-inference.md
+++ b/accelerated-inference.md
@@ -7,7 +7,7 @@ thumbnail: /blog/assets/09_accelerated_inference/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published Jan 18, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/accelerated-inference.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/accelerated-inference.md">
         Update on GitHub
     </a>
 </div>

--- a/accelerating-pytorch.md
+++ b/accelerating-pytorch.md
@@ -10,7 +10,7 @@ Accelerating PyTorch distributed fine-tuning with Intel technologies
 
 <div class="blog-metadata">
     <small>Published November 19, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/juliensimon/blog/blob/master/large-language-models.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/juliensimon/blog/blob/main/large-language-models.md">
         Update on GitHub
     </a>
 </div>

--- a/asr-chunking.md
+++ b/asr-chunking.md
@@ -9,7 +9,7 @@ thumbnail: /blog/assets/49_asr_chunking/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published February 1, 2022.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/asr-chunking.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/asr-chunking.md">
         Update on GitHub
     </a>
 </div>

--- a/autonlp-prodigy.md
+++ b/autonlp-prodigy.md
@@ -7,7 +7,7 @@ thumbnail: /blog/assets/43_autonlp_prodigy/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published Dec 17, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/autonlp-prodigy.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/autonlp-prodigy.md">
         Update on GitHub
     </a>
 </div>

--- a/bert-cpu-scaling-part-2.md
+++ b/bert-cpu-scaling-part-2.md
@@ -6,7 +6,7 @@ title: "Scaling up BERT-like model Inference on modern CPU  - Part 2"
 
 <div class="blog-metadata">
     <small>Published November 4th, 2021</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/bert-cpu-scaling-part-2.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/bert-cpu-scaling-part-2.md">
         Update on GitHub
     </a>
 </div>

--- a/bert-inferentia-sagemaker.md
+++ b/bert-inferentia-sagemaker.md
@@ -7,7 +7,7 @@ thumbnail: /blog//assets/55_bert_inferentia_sagemaker/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published March 16, 2022.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/bert-inferentia-sagemaker.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/bert-inferentia-sagemaker.md">
         Update on GitHub
     </a>
 </div>

--- a/big-bird.md
+++ b/big-bird.md
@@ -9,7 +9,7 @@ thumbnail: /blog/assets/18_big_bird/attn.png
 
 <div class="blog-metadata">
     <small>Published March 31, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/big-bird.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/big-bird.md">
         Update on GitHub
     </a>
 </div>

--- a/codeparrot.md
+++ b/codeparrot.md
@@ -7,7 +7,7 @@ thumbnail: /blog/assets/40_codeparrot/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published Dec 8, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/codeparrot.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/codeparrot.md">
         Update on GitHub
     </a>
 </div>

--- a/collaborative-training.md
+++ b/collaborative-training.md
@@ -7,7 +7,7 @@ thumbnail: /blog/assets/24_sahajBERT/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published July 15, 2021</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/collaborative-training.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/collaborative-training.md">
         Update on GitHub
     </a>
 </div>

--- a/constrained-beam-search.md
+++ b/constrained-beam-search.md
@@ -9,7 +9,7 @@ thumbnail: /blog/assets/53_constrained_beam_search/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published March 11, 2022.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/constrained-beam-search.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/constrained-beam-search.md">
         Update on GitHub
     </a>
 </div>
@@ -25,7 +25,7 @@ thumbnail: /blog/assets/53_constrained_beam_search/thumbnail.png
     </a>
 </div>
 
-<a target="_blank" href="https://colab.research.google.com/github/huggingface/blog/blob/master/notebooks/53_constrained_beam_search.ipynb">
+<a target="_blank" href="https://colab.research.google.com/github/huggingface/blog/blob/main/notebooks/53_constrained_beam_search.ipynb">
     <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 
@@ -46,7 +46,7 @@ $$ S_{expected} = \{ s_1, s_2, ..., s_k, t_1, t_2, s_{k+1}, ..., s_n \} $$
 
 The problem is that beam search generates the sequence *token-by-token*. Though not entirely accurate, one can think of beam search as the function \\( B(\mathbf{s}_{0:i}) = s_{i+1} \\), where it looks as the currently generated sequence of tokens from \\( 0 \\) to \\( i \\) then predicts the next token at \\( i+1 \\) . But how can this function know, at an arbitrary step \\( i < k \\) , that the tokens must be generated at some future step \\( k \\) ? Or when it's at the step \\( i=k \\) , how can it know for sure that this is the best spot to force the tokens, instead of some future step \\( i>k \\) ?
 
-![Why constraints are hard](https://raw.githubusercontent.com/huggingface/blog/master/assets/53_constrained_beam_search/why_constraints_are_hard.png)
+![Why constraints are hard](https://raw.githubusercontent.com/huggingface/blog/main/assets/53_constrained_beam_search/why_constraints_are_hard.png)
 
 
 And what if you have multiple constraints with varying requirements? What if you want to force the phrase \\( p_1=\{t_1, t_2\} \\) *and* also the phrase \\( p_2=\{ t_3, t_4, t_5, t_6\} \\) ? What if you want the model to **choose between** the two phrases? What if we want to force the phrase \\( p_1 \\) and force just one phrase among the list of phrases \\( \{p_{21}, p_{22}, p_{23}\} \\) ? 
@@ -209,13 +209,13 @@ Unlike greedy search, beam search works by keeping a longer list of hypotheses. 
 
 Here's another way to look at the first step of the beam search for the above example, in the case of `num_beams=3`:
 
-![Beam search step 1](https://raw.githubusercontent.com/huggingface/blog/master/assets/53_constrained_beam_search/beam_1.jpg)
+![Beam search step 1](https://raw.githubusercontent.com/huggingface/blog/main/assets/53_constrained_beam_search/beam_1.jpg)
 
 Instead of only choosing `"The dog"` like what a greedy search would do, a beam search would allow *further consideration* of `"The nice"` and `"The car"`.
 
 In the next step, we consider the next possible tokens for each of the three branches we created in the previous step.
 
-![Beam search step 2](https://raw.githubusercontent.com/huggingface/blog/master/assets/53_constrained_beam_search/beam_2.jpg)
+![Beam search step 2](https://raw.githubusercontent.com/huggingface/blog/main/assets/53_constrained_beam_search/beam_2.jpg)
 
 Though we end up *considering* significantly more than `num_beams` outputs, we reduce them down to `num_beams` at the end of the step. We can't just keep branching out, then the number of `beams` we'd have to keep track of would be \\( \text{beams}^{n} \\) for \\( n \\) steps, which becomes very large very quickly ( \\( 10 \\) beams after \\( 10 \\) steps is \\( 10,000,000,000 \\) beams!). 
 
@@ -237,13 +237,13 @@ Let's say that we're trying to force the phrase `"is fast"` in the generation ou
 In the traditional beam search setting, we find the top `k` most probable next tokens at each branch and append them for consideration. In the constrained setting, we do the same but also append the tokens that will take us *closer to fulfilling our constraints*. Here's a demonstration:
 
 
-![Constrained Beam Search Step 1](https://raw.githubusercontent.com/huggingface/blog/master/assets/53_constrained_beam_search/cbeam_1.jpg)
+![Constrained Beam Search Step 1](https://raw.githubusercontent.com/huggingface/blog/main/assets/53_constrained_beam_search/cbeam_1.jpg)
 
 On top of the usual high-probability next tokens like `"dog"` and `"nice"`, we force the token `"is"` in order to get us closer to fulfilling our constraint of `"is fast"`.
 
 For the next step, the branched-out candidates below are mostly the same as that of traditional beam search. But like the above example, constrained beam search adds onto the existing candidates by forcing the constraints at each new branch:
 
-![Constrained Beam Search Step 2](https://raw.githubusercontent.com/huggingface/blog/master/assets/53_constrained_beam_search/cbeam_2.jpg)
+![Constrained Beam Search Step 2](https://raw.githubusercontent.com/huggingface/blog/main/assets/53_constrained_beam_search/cbeam_2.jpg)
 
 ### **Banks**
 
@@ -259,7 +259,7 @@ This way, even though we're *forcing* the model to consider the branch where we'
 
 This behavior is demonstrated in the third step of the above example:
 
-![Constrained Beam Search Step 3](https://raw.githubusercontent.com/huggingface/blog/master/assets/53_constrained_beam_search/cbeam_3.jpg)
+![Constrained Beam Search Step 3](https://raw.githubusercontent.com/huggingface/blog/main/assets/53_constrained_beam_search/cbeam_3.jpg)
 
 Notice how `"The is fast"` doesn't require any manual appending of constraint tokens since it's already fulfilled (i.e., already contains the phrase `"is fast"`). Also, notice how beams like `"The dog is slow"` or `"The dog is mad"` is actually in Bank 0, since, although it includes the token `"is"`, it must restart from the beginning to generate `"is fast"`. By appending something like `"slow"` after `"is"`, it has effectively *reset its progress*. 
 

--- a/data-measurements-tool.md
+++ b/data-measurements-tool.md
@@ -7,7 +7,7 @@ thumbnail: /blog/assets/37_data-measurements-tool/datametrics.png
 
 <div class="blog-metadata">
     <small>Published November 29, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/data-measurements-tool.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/data-measurements-tool.md">
         Update on GitHub
     </a>
 </div>

--- a/deploy-hugging-face-models-easily-with-amazon-sagemaker.md
+++ b/deploy-hugging-face-models-easily-with-amazon-sagemaker.md
@@ -7,7 +7,7 @@ thumbnail: /blog/assets/17_the_partnership_amazon_sagemaker_and_hugging_face/thu
 
 <div class="blog-metadata">
     <small>Published July 8, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/deploy-hugging-face-models-easily-with-amazon-sagemaker.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/deploy-hugging-face-models-easily-with-amazon-sagemaker.md">
         Update on GitHub
     </a>
 </div>

--- a/encoder-decoder.md
+++ b/encoder-decoder.md
@@ -7,7 +7,7 @@ thumbnail: /blog/assets/05_encoder_decoder/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published October 08, 2020.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/encoder-decoder.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/encoder-decoder.md">
         Update on GitHub
     </a>
 </div>

--- a/few-shot-learning-gpt-neo-and-inference-api.md
+++ b/few-shot-learning-gpt-neo-and-inference-api.md
@@ -9,7 +9,7 @@ title: 'Few-shot learning in practice: GPT-Neo and the 🤗 Accelerated Inferenc
 
 <div class="blog-metadata">
     <small>Published June 3, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/few-shot-learning-gpt-neo-and-inference-api.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/few-shot-learning-gpt-neo-and-inference-api.md">
         Update on GitHub
     </a>
 </div>

--- a/fine-tune-segformer.md
+++ b/fine-tune-segformer.md
@@ -9,7 +9,7 @@ thumbnail: /blog/assets/56_fine_tune_segformer/thumb.png
 
 <div class="blog-metadata">
     <small>Published March 17, 2022.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/fine-tune-segformer.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/fine-tune-segformer.md">
         Update on GitHub
     </a>
 </div>

--- a/fine-tune-vit.md
+++ b/fine-tune-vit.md
@@ -9,7 +9,7 @@ thumbnail: /blog/assets/51_fine_tune_vit/vit-thumbnail.jpg
 
 <div class="blog-metadata">
     <small>Published February 11, 2022.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/fine-tune-vit.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/fine-tune-vit.md">
         Update on GitHub
     </a>
 </div>

--- a/fine-tune-wav2vec2-english.md
+++ b/fine-tune-wav2vec2-english.md
@@ -9,7 +9,7 @@ thumbnail: /blog/assets/15_fine_tune_wav2vec2/wav2vec2.png
 
 <div class="blog-metadata">
     <small>Published March 12, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/fine-tune-wav2vec2-english.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/fine-tune-wav2vec2-english.md">
         Update on GitHub
     </a>
 </div>

--- a/fine-tune-xlsr-wav2vec2.md
+++ b/fine-tune-xlsr-wav2vec2.md
@@ -9,7 +9,7 @@ thumbnail: /blog/assets/xlsr_wav2vec2.png
 
 <div class="blog-metadata">
     <small>Updated November 15, 2021. Originally published March 12, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/fine-tune-xlsr-wav2vec2.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/fine-tune-xlsr-wav2vec2.md">
         Update on GitHub
     </a>
 </div>

--- a/gptj-sagemaker.md
+++ b/gptj-sagemaker.md
@@ -7,7 +7,7 @@ thumbnail: /blog/assets/45_gptj_sagemaker/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published Jan 11, 2022.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/gptj-sagemaker.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/gptj-sagemaker.md">
         Update on GitHub
     </a>
 </div>

--- a/gradio-joins-hf.md
+++ b/gradio-joins-hf.md
@@ -7,7 +7,7 @@ thumbnail: /blog/assets/42_gradio_joins_hf/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published December 21, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/gradio-joins-hf.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/gradio-joins-hf.md">
         Update on GitHub
     </a>
 </div>

--- a/gradio-spaces.md
+++ b/gradio-spaces.md
@@ -10,7 +10,7 @@ thumbnail: /blog/assets/28_gradio-spaces/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published October 5, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/gradio-spaces.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/gradio-spaces.md">
         Update on GitHub
     </a>
 </div>

--- a/gradio.md
+++ b/gradio.md
@@ -8,7 +8,7 @@ thumbnail: /blog/assets/22_gradio/gradio.png
 > ##### Cross-posted from the&nbsp;[Gradio blog](https://gradio.app/blog/using-huggingface-models).
 
 <div class="blog-metadata">
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/gradio.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/gradio.md">
         Update on GitHub
     </a>
 </div>

--- a/graphcore.md
+++ b/graphcore.md
@@ -6,7 +6,7 @@ thumbnail: /blog/assets/26_graphcore-ipu/thumbnail.png
 # Hugging Face and Graphcore partner for IPU-optimized Transformers
 
 <div class="blog-metadata">
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/graphcore-ipu.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/graphcore-ipu.md">
         Update on GitHub
     </a>
 </div>

--- a/hardware-partners-program.md
+++ b/hardware-partners-program.md
@@ -7,7 +7,7 @@ title: "Introducing Optimum: The Optimization Toolkit for Transformers at Scale"
 
 <div class="blog-metadata">
     <small>Published September 14, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/hardware-partners-program.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/hardware-partners-program.md">
         Update on GitHub
     </a>
 </div>

--- a/how-to-deploy-a-pipeline-to-google-clouds.md
+++ b/how-to-deploy-a-pipeline-to-google-clouds.md
@@ -7,7 +7,7 @@ thumbnail: /blog/assets/14_how_to_deploy_a_pipeline_to_google_clouds/thumbnail.p
 
 <div class="blog-metadata">
     <small>Published March 18, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/how-to-deploy-a-pipeline-to-google-clouds.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/how-to-deploy-a-pipeline-to-google-clouds.md">
         Update on GitHub
     </a>
 </div>

--- a/how-to-generate.md
+++ b/how-to-generate.md
@@ -7,7 +7,7 @@ thumbnail: /blog/assets/02_how-to-generate/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published March 18, 2020.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/how-to-generate.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/how-to-generate.md">
         Update on GitHub
     </a>
 </div>
@@ -22,7 +22,7 @@ thumbnail: /blog/assets/02_how-to-generate/thumbnail.png
     </a>
 </div>
 
-<a target="_blank" href="https://colab.research.google.com/github/huggingface/blog/blob/master/notebooks/02_how_to_generate.ipynb">
+<a target="_blank" href="https://colab.research.google.com/github/huggingface/blog/blob/main/notebooks/02_how_to_generate.ipynb">
     <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 

--- a/how-to-train.md
+++ b/how-to-train.md
@@ -7,12 +7,12 @@ thumbnail: /blog/assets/01_how-to-train/how-to-train_blogpost.png
 
 <div class="blog-metadata">
     <small>Published Feb 14, 2020. Last update May 15.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/how-to-train.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/how-to-train.md">
         Update on GitHub
     </a>
 </div>
 
-<a target="_blank" href="https://colab.research.google.com/github/huggingface/blog/blob/master/notebooks/01_how_to_train.ipynb">
+<a target="_blank" href="https://colab.research.google.com/github/huggingface/blog/blob/main/notebooks/01_how_to_train.ipynb">
     <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab">
 </a>
 

--- a/image-search-datasets.md
+++ b/image-search-datasets.md
@@ -7,7 +7,7 @@ thumbnail: /blog/assets/54_image_search_datasets/spaces_image_search.jpg
 
 <div class="blog-metadata">
     <small>Published March 16, 2022.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/image-search-datasets.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/image-search-datasets.md">
         Update on GitHub
     </a>
 </div>

--- a/infinity-cpu-performance.md
+++ b/infinity-cpu-performance.md
@@ -7,7 +7,7 @@ thumbnail: /blog/assets/46_infinity_cpu_performance/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published Jan 13, 2022.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/infinity-cpu-performance.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/infinity-cpu-performance.md">
         Update on GitHub
     </a>
 </div>

--- a/large-language-models.md
+++ b/large-language-models.md
@@ -10,7 +10,7 @@ Large Language Models: A New Moore's Law?
 
 <div class="blog-metadata">
     <small>Published October 26, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/juliensimon/blog/blob/master/large-language-models.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/juliensimon/blog/blob/main/large-language-models.md">
         Update on GitHub
     </a>
 </div>

--- a/long-range-transformers.md
+++ b/long-range-transformers.md
@@ -14,7 +14,7 @@ thumbnail: /blog/assets/14_long_range_transformers/EfficientTransformerTaxonomy.
 
 <div class="blog-metadata">
     <small>Published March 09, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/long-range-transformers.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/long-range-transformers.md">
         Update on GitHub
     </a>
 </div>

--- a/notebooks/02_how_to_generate.ipynb
+++ b/notebooks/02_how_to_generate.ipynb
@@ -23,7 +23,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/huggingface/blog/blob/master/notebooks/02_how_to_generate.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/huggingface/blog/blob/main/notebooks/02_how_to_generate.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {

--- a/perceiver.md
+++ b/perceiver.md
@@ -7,7 +7,7 @@ thumbnail: /blog/assets/41_perceiver/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published December 15, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/perceiver.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/perceiver.md">
         Update on GitHub
     </a>
 </div>

--- a/porting-fsmt.md
+++ b/porting-fsmt.md
@@ -7,7 +7,7 @@ thumbnail: /blog/assets/07_porting_fsmt/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published November 3, 2020.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/porting-fsmt.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/porting-fsmt.md">
         Update on GitHub
     </a>
 </div>

--- a/pytorch-xla.md
+++ b/pytorch-xla.md
@@ -7,7 +7,7 @@ thumbnail: /blog/assets/13_pytorch_xla/pytorch_xla_thumbnail.png
 
 <div class="blog-metadata">
     <small>Published February 9, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/pytorch-xla.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/pytorch-xla.md">
         Update on GitHub
     </a>
 </div>
@@ -31,7 +31,7 @@ thumbnail: /blog/assets/13_pytorch_xla/pytorch_xla_thumbnail.png
     </a>
 </div>
 
-<a href="https://colab.research.google.com/github/huggingface/blog/blob/master/notebooks/13_pytorch_xla.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
+<a href="https://colab.research.google.com/github/huggingface/blog/blob/main/notebooks/13_pytorch_xla.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
 
 ## Training Your Favorite Transformers on Cloud TPUs using PyTorch / XLA
 

--- a/pytorch_block_sparse.md
+++ b/pytorch_block_sparse.md
@@ -7,7 +7,7 @@ thumbnail: /blog/assets/04_pytorch_block_sparse/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published Sep 10, 2020.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/pytorch_block_sparse.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/pytorch_block_sparse.md">
         Update on GitHub
     </a>
 </div>

--- a/ray-rag.md
+++ b/ray-rag.md
@@ -7,7 +7,7 @@ thumbnail: /blog/assets/12_ray_rag/ray_arch_updated.png
 
 <div class="blog-metadata">
     <small>Published Feb 10, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/ray-rag.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/ray-rag.md">
         Update on GitHub
     </a>
 </div>

--- a/ray-tune.md
+++ b/ray-tune.md
@@ -9,7 +9,7 @@ thumbnail: /blog/assets/06_ray_tune/ray-hf.jpg
 
 <div class="blog-metadata">
     <small>Published Nov 2, 2020.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/ray-tune.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/ray-tune.md">
         Update on GitHub
     </a>
 </div>

--- a/reformer.md
+++ b/reformer.md
@@ -7,7 +7,7 @@ thumbnail: /blog/assets/03_reformer/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published July 3, 2020.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/reformer.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/reformer.md">
         Update on GitHub
     </a>
 </div>
@@ -22,7 +22,7 @@ thumbnail: /blog/assets/03_reformer/thumbnail.png
     </a>
 </div>
 
-<a href="https://colab.research.google.com/github/patrickvonplaten/blog/blob/master/notebooks/03_reformer.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
+<a href="https://colab.research.google.com/github/patrickvonplaten/blog/blob/main/notebooks/03_reformer.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
 
 
 ## How the Reformer uses less than 8GB of RAM to train on sequences of half a million tokens

--- a/sagemaker-distributed-training-seq2seq.md
+++ b/sagemaker-distributed-training-seq2seq.md
@@ -9,7 +9,7 @@ thumbnail: /blog/assets/19_sagemaker_distributed_training_seq2seq/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published April 8, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/sagemaker-distributed-training-seq2seq.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/sagemaker-distributed-training-seq2seq.md">
         Update on GitHub
     </a>
 </div>

--- a/sb3.md
+++ b/sb3.md
@@ -9,7 +9,7 @@ thumbnail: /blog/assets/47_sb3/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published January 21, 2022.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/sb3.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/sb3.md">
         Update on GitHub
     </a>
 </div>

--- a/searching-the-hub.md
+++ b/searching-the-hub.md
@@ -9,7 +9,7 @@ thumbnail: /blog/assets/48_hubsearch/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published January 25, 2022.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/searching-the-hub.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/searching-the-hub.md">
         Update on GitHub
     </a>
 </div>

--- a/sentence-transformers-in-the-hub.md
+++ b/sentence-transformers-in-the-hub.md
@@ -8,7 +8,7 @@ title: "Sentence Transformers in the Hugging Face Hub"
 
 <div class="blog-metadata">
     <small>Published June 28, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/sentence-transformers-in-the-hub.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/sentence-transformers-in-the-hub.md">
         Update on GitHub
     </a>
 </div>

--- a/sentiment-analysis-python.md
+++ b/sentiment-analysis-python.md
@@ -7,7 +7,7 @@ thumbnail: /blog/assets/50_sentiment_python/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published Feb 2, 2022.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/sentiment-analysis-python.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/sentiment-analysis-python.md">
         Update on GitHub
     </a>
 </div>

--- a/simple-considerations.md
+++ b/simple-considerations.md
@@ -11,7 +11,7 @@ thumbnail: /blog/assets/13_simple-considerations/henry-co-3coKbdfnAFg-unsplash.j
 
 <div class="blog-metadata">
     <small>Published February 25, 2021 – <span class="">Initially published on Medium, Sept 2020.</span></small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/simple-considerations.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/simple-considerations.md">
         Update on GitHub
     </a>
 </div>

--- a/snowball-fight.md
+++ b/snowball-fight.md
@@ -9,7 +9,7 @@ thumbnail: /blog/assets/39_introducing_snowball_fight/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published December 2, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/snowball-fight.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/snowball-fight.md">
         Update on GitHub
     </a>
 </div>

--- a/spacy.md
+++ b/spacy.md
@@ -10,7 +10,7 @@ thumbnail: /blog/assets/23_spacy/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published July 13, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/spacy.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/spacy.md">
         Update on GitHub
     </a>
 </div>

--- a/streamlit-spaces.md
+++ b/streamlit-spaces.md
@@ -10,7 +10,7 @@ thumbnail: /blog/assets/29_streamlit-spaces/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published October 5, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/streamlit-spaces.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/streamlit-spaces.md">
         Update on GitHub
     </a>
 </div>

--- a/summer-at-huggingface.md
+++ b/summer-at-huggingface.md
@@ -8,7 +8,7 @@ thumbnail: /blog/assets/27_summer_at_huggingface/summer_intro.gif
 
 <div class="blog-metadata">
     <small>Published September 24, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/summer-at-huggingface.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/summer-at-huggingface.md">
         Update on GitHub
     </a>
 </div>

--- a/tf-serving.md
+++ b/tf-serving.md
@@ -7,7 +7,7 @@ thumbnail: /blog/assets/10_tf-serving/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published January 26, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/tf-serving.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/tf-serving.md">
         Update on GitHub
     </a>
 </div>
@@ -22,7 +22,7 @@ thumbnail: /blog/assets/10_tf-serving/thumbnail.png
     </a>
 </div>
 
-<a target="_blank" href="https://colab.research.google.com/github/huggingface/blog/blob/master/notebooks/10_tf_serving.ipynb">
+<a target="_blank" href="https://colab.research.google.com/github/huggingface/blog/blob/main/notebooks/10_tf_serving.ipynb">
     <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab">
 </a>
 

--- a/the-age-of-ml-as-code.md
+++ b/the-age-of-ml-as-code.md
@@ -10,7 +10,7 @@ The Age of Machine Learning As Code Has Arrived
 
 <div class="blog-metadata">
     <small>Published October 20, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/the-age-of-ml-as-code.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/the-age-of-ml-as-code.md">
         Update on GitHub
     </a>
 </div>

--- a/warm-starting-encoder-decoder.md
+++ b/warm-starting-encoder-decoder.md
@@ -8,7 +8,7 @@ thumbnail: /blog/assets/08_warm_starting_encoder_decoder/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published November 09, 2020.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/warm-starting-encoder-decoder.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/warm-starting-encoder-decoder.md">
       Update on GitHub
     </a>
 </div>

--- a/wav2vec2-with-ngram.md
+++ b/wav2vec2-with-ngram.md
@@ -9,7 +9,7 @@ thumbnail: /blog/assets/44_boost_wav2vec2_ngram/wav2vec2_ngram.png
 
 <div class="blog-metadata">
     <small>Published January 12, 2022.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/wav2vec2-with-ngram.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/wav2vec2-with-ngram.md">
         Update on GitHub
     </a>
 </div>

--- a/zero-deepspeed-fairscale.md
+++ b/zero-deepspeed-fairscale.md
@@ -7,7 +7,7 @@ thumbnail: /blog/assets/11_zero_deepspeed_fairscale/zero-partitioning.png
 
 <div class="blog-metadata">
     <small>Published January 19, 2021.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/master/zero-deepspeed-fairscale.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/zero-deepspeed-fairscale.md">
         Update on GitHub
     </a>
 </div>


### PR DESCRIPTION
this is not super crucial b/c GitHub redirects renamed branches, but for consistency this is nice