### PR TITLE
Clarification for the usage of  load_from_hub in sb3.md

### DIFF
--- a/sb3.md
+++ b/sb3.md
@@ -65,10 +65,10 @@ from stable_baselines3.common.evaluation import evaluate_policy
 
 # Retrieve the model from the hub
 ## repo_id = id of the model repository from the Hugging Face Hub (repo_id = {organization}/{repo_name})
-## filename = name of the model zip file from the repository
+## filename = name of the model zip file from the repository including the extension .zip
 checkpoint = load_from_hub(
     repo_id="sb3/demo-hf-CartPole-v1",
-    filename="ppo-CartPole-v1",
+    filename="ppo-CartPole-v1.zip",
 )
 model = PPO.load(checkpoint)
 


### PR DESCRIPTION
Added .zip extension to filename example in load_from_hub. This is way it is consistent with the intended usage (without the extension, we would get "HTTPError: 404 Client Error")