### PR TITLE
Fix blog post with HTML in title

### DIFF
--- a/transformers-design-philosophy.md
+++ b/transformers-design-philosophy.md
@@ -1,5 +1,5 @@
 ---
-title: "Don't Repeat Yourself"
+title: "~Don't~ Repeat Yourself"
 thumbnail: /blog/assets/59_transformers_philosophy/transformers.png
 ---
 

--- a/transformers-design-philosophy.md
+++ b/transformers-design-philosophy.md
@@ -1,5 +1,5 @@
 ---
-title: "<del>Don't</del> Repeat Yourself \\( {}^{\textbf{*}} \\)"
+title: "Don't Repeat Yourself"
 thumbnail: /blog/assets/59_transformers_philosophy/transformers.png
 ---
 


### PR DESCRIPTION
Fix: https://github.com/huggingface/moon-landing/issues/2634

Decided just to fix this one post to keep things uncomplicated :)

Removes the HTML tags from the title of the transformers-design-philosophy blog. 