### PR TITLE
Adjust links to hub docs

### DIFF
--- a/carbon-emissions-on-the-hub.md
+++ b/carbon-emissions-on-the-hub.md
@@ -154,7 +154,7 @@ An example of this data being included at the top of the model card is shown bel
 
 ![Visual of organizing the co2_eq_emissions in a Model Card file](assets/60_carbon_emissions_on_the_hub/metadata_example.png)
 
-For more references on the metadata format for `co2_eq_emissions ` see [the hub docs](https://huggingface.co/docs/hub/model-repos#carbon-footprint-metadata).
+For more references on the metadata format for `co2_eq_emissions ` see [the hub docs](https://huggingface.co/docs/hub/models-cards-co2).
 
 ### Further readings
 

--- a/fastai.md
+++ b/fastai.md
@@ -51,7 +51,7 @@ Anyone can access all the fastai models in the Hub by filtering the [hf.co/model
 
 ![Fastai Models in the Hub](assets/64_fastai/hf_hub_fastai.png)
 
-In addition to free model hosting and exposure to the broader community, the Hub has built-in [version control based on git](https://huggingface.co/docs/transformers/model_sharing#repository-features) (git-lfs, for large files) and [model cards](https://huggingface.co/docs/hub/model-repos#what-are-model-cards-and-why-are-they-useful) for discoverability and reproducibility. For more information on navigating the Hub, see [this introduction](https://github.com/huggingface/education-toolkit/blob/main/01_huggingface-hub-tour.md).
+In addition to free model hosting and exposure to the broader community, the Hub has built-in [version control based on git](https://huggingface.co/docs/transformers/model_sharing#repository-features) (git-lfs, for large files) and [model cards](https://huggingface.co/docs/hub/models-cards) for discoverability and reproducibility. For more information on navigating the Hub, see [this introduction](https://github.com/huggingface/education-toolkit/blob/main/01_huggingface-hub-tour.md).
 
 
 
@@ -113,7 +113,7 @@ repo_id = "espejelomar/identify-my-cat"
 push_to_hub_fastai(learner=learn, repo_id=repo_id)
 ```
 
-The `Learner` is now in the Hub in the repo named [`espejelomar/identify-my-cat`](https://huggingface.co/espejelomar/identify-my-cat). An automatic model card is created with some links and next steps. When uploading a fastai `Learner` (or any other model) to the Hub, it is helpful to edit its model card (image below) so that others better understand your work (refer to the [Hugging Face documentation](https://huggingface.co/docs/hub/model-repos#what-are-model-cards-and-why-are-they-useful)).
+The `Learner` is now in the Hub in the repo named [`espejelomar/identify-my-cat`](https://huggingface.co/espejelomar/identify-my-cat). An automatic model card is created with some links and next steps. When uploading a fastai `Learner` (or any other model) to the Hub, it is helpful to edit its model card (image below) so that others better understand your work (refer to the [Hugging Face documentation](https://huggingface.co/docs/hub/models-cards)).
 
 ![Fastai Model Card](assets/64_fastai/hf_model_card.png)
 
@@ -236,7 +236,7 @@ Take the [fast.ai course](https://course.fast.ai/) (a new version is coming soon
 
 ### Would you like to integrate your library to the Hub?
 
-This integration is made possible by the [`huggingface_hub`](https://github.com/huggingface/huggingface_hub) library. If you want to add your library to the Hub, we have a [guide](https://huggingface.co/docs/hub/adding-a-library) for you! Or simply tag someone from the Hugging Face team.
+This integration is made possible by the [`huggingface_hub`](https://github.com/huggingface/huggingface_hub) library. If you want to add your library to the Hub, we have a [guide](https://huggingface.co/docs/hub/models-adding-libraries) for you! Or simply tag someone from the Hugging Face team.
 
 A shout out to the Hugging Face team for all the work on this integration, in particular [@osanseviero](https://twitter.com/osanseviero) 🦙.
 

--- a/notebooks/64_fastai_hub.ipynb
+++ b/notebooks/64_fastai_hub.ipynb
@@ -56,7 +56,7 @@
         "id": "Pqz3uTc8NKsP"
       },
       "source": [
-        "In addition to free model hosting and exposure to the broader community, the Hub has built-in [version control based on git](https://huggingface.co/docs/transformers/model_sharing#repository-features) (git-lfs, for large files) and [model cards](https://huggingface.co/docs/hub/model-repos#what-are-model-cards-and-why-are-they-useful) for discoverability and reproducibility. For more information on navigating the Hub, see [this introduction](https://github.com/huggingface/education-toolkit/blob/main/01_huggingface-hub-tour.md)."
+        "In addition to free model hosting and exposure to the broader community, the Hub has built-in [version control based on git](https://huggingface.co/docs/transformers/model_sharing#repository-features) (git-lfs, for large files) and [model cards](https://huggingface.co/docs/hub/models-cards) for discoverability and reproducibility. For more information on navigating the Hub, see [this introduction](https://github.com/huggingface/education-toolkit/blob/main/01_huggingface-hub-tour.md)."
       ]
     },
     {
@@ -545,7 +545,7 @@
         "id": "7jEdVBkFPt9e"
       },
       "source": [
-        "The `Learner` is now in the Hub in the repo named [`espejelomar/identify-my-cat`](https://huggingface.co/espejelomar/identify-my-cat). An automatic model card is created with some links and next steps. When uploading a fastai `Learner` (or any other model) to the Hub, it is helpful to edit its model card (image below) so that others better understand your work (refer to the [Hugging Face documentation](https://huggingface.co/docs/hub/model-repos#what-are-model-cards-and-why-are-they-useful)).\n"
+        "The `Learner` is now in the Hub in the repo named [`espejelomar/identify-my-cat`](https://huggingface.co/espejelomar/identify-my-cat). An automatic model card is created with some links and next steps. When uploading a fastai `Learner` (or any other model) to the Hub, it is helpful to edit its model card (image below) so that others better understand your work (refer to the [Hugging Face documentation](https://huggingface.co/docs/hub/models-cards)).\n"
       ]
     },
     {
@@ -1158,7 +1158,7 @@
         "\n",
         "### Would you like to integrate your library to the Hub?\n",
         "\n",
-        "This integration is made possible by the [`huggingface_hub`](https://github.com/huggingface/huggingface_hub) library. If you want to add your library to the Hub, we have a [guide](https://huggingface.co/docs/hub/adding-a-library) for you! Or simply tag someone from the Hugging Face team."
+        "This integration is made possible by the [`huggingface_hub`](https://github.com/huggingface/huggingface_hub) library. If you want to add your library to the Hub, we have a [guide](https://huggingface.co/docs/hub/models-adding-libraries) for you! Or simply tag someone from the Hugging Face team."
       ]
     },
     {

--- a/sb3.md
+++ b/sb3.md
@@ -158,4 +158,4 @@ Finally, we would like to thank the SB3 team and in particular [Antonin Raffin](
 
 ### Would you like to integrate your library to the Hub?
 
-This integration is possible thanks to the [`huggingface_hub`](https://github.com/huggingface/huggingface_hub) library which has all our widgets and the API for all our supported libraries. If you would like to integrate your library to the Hub, we have a [guide](https://huggingface.co/docs/hub/adding-a-library) for you!
+This integration is possible thanks to the [`huggingface_hub`](https://github.com/huggingface/huggingface_hub) library which has all our widgets and the API for all our supported libraries. If you would like to integrate your library to the Hub, we have a [guide](https://huggingface.co/docs/hub/models-adding-libraries) for you!

--- a/searching-the-hub.md
+++ b/searching-the-hub.md
@@ -241,4 +241,4 @@ A very brief example of this is if we have an `AttributeDictionary` with a key o
 
 Hopefully by now you have a brief understanding of how this new searching API can directly impact your workflow and exploration of the Hub! Along with this, perhaps you know of a place in your code where the `AttributeDictionary` might be useful for you to use.
 
-From here, make sure to check out the official documentation on [Searching the Hub Efficiently](https://huggingface.co/docs/hub/searching-the-hub) and don't forget to give us a [star](https://github.com/huggingface/huggingface_hub)!
+From here, make sure to check out the official documentation on [Searching the Hub Efficiently](https://huggingface.co/docs/huggingface_hub/searching-the-hub) and don't forget to give us a [star](https://github.com/huggingface/huggingface_hub)!

--- a/sentence-transformers-in-the-hub.md
+++ b/sentence-transformers-in-the-hub.md
@@ -129,7 +129,7 @@ If you don't have any model in the Hub and want to learn more about Sentence Tra
 
 ## Would you like to integrate your library to the Hub?
 
-This integration is possible thanks to the [`huggingface_hub`](https://github.com/huggingface/huggingface_hub) library which has all our widgets and the API for all our supported libraries. If you would like to integrate your library to the Hub, we have a [guide](https://huggingface.co/docs/hub/adding-a-library) for you!
+This integration is possible thanks to the [`huggingface_hub`](https://github.com/huggingface/huggingface_hub) library which has all our widgets and the API for all our supported libraries. If you would like to integrate your library to the Hub, we have a [guide](https://huggingface.co/docs/hub/models-adding-libraries) for you!
 
 ## References
 

--- a/spacy.md
+++ b/spacy.md
@@ -104,4 +104,4 @@ Try it out and share your models with the community!
 
 ## Would you like to integrate your library to the Hub?
 
-This integration is possible thanks to the [`huggingface_hub`](https://github.com/huggingface/huggingface_hub) library which has all our widgets and the API for all our supported libraries. If you would like to integrate your library to the Hub, we have a [guide](https://huggingface.co/docs/hub/adding-a-library) for you!
+This integration is possible thanks to the [`huggingface_hub`](https://github.com/huggingface/huggingface_hub) library which has all our widgets and the API for all our supported libraries. If you would like to integrate your library to the Hub, we have a [guide](https://huggingface.co/docs/hub/models-adding-libraries) for you!

--- a/streamlit-spaces.md
+++ b/streamlit-spaces.md
@@ -103,7 +103,7 @@ You can see the interactive bar chart, dataframe component and hosted matplotlib
 
 ## Hosting your Projects in Hugging Face Spaces
 
-You can simply drag and drop your files as shown below. Note that you need to include your additional dependencies in the requirements.txt. Also note that the version of Streamlit you have on your local is the same. For seamless usage, refer to [Spaces API reference](https://huggingface.co/docs/hub/spaces#reference). 
+You can simply drag and drop your files as shown below. Note that you need to include your additional dependencies in the requirements.txt. Also note that the version of Streamlit you have on your local is the same. For seamless usage, refer to [Spaces API reference](https://huggingface.co/docs/hub/spaces-config-reference). 
 
 ![spaces-streamlit](assets/29_streamlit-spaces/streamlit.gif)
 

--- a/summer-at-huggingface.md
+++ b/summer-at-huggingface.md
@@ -46,7 +46,7 @@ In the last few months, the Hub went from 10,000 public model repositories to ov
 
 Spaces is a simple and free solution to host Machine Learning demo applications directly on your user profile or your organization [hf.co](http://hf.co/) profile. We support two awesome SDKs that let you build cool apps easily in Python: [Gradio](https://gradio.app/) and [Streamlit](https://streamlit.io/). In a matter of minutes you can deploy an app and share it with the community! 🚀
 
-Spaces lets you [set up secrets](/docs/hub/spaces#secret-management), permits [custom requirements](/docs/hub/spaces#how-can-i-install-other-dependencies), and can even be managed [directly from GitHub repos](/docs/hub/spaces#how-can-i-manage-my-app-through-github). You can sign up for the beta at [hf.co/spaces](/spaces). Here are some of our favorites!
+Spaces lets you [set up secrets](/docs/hub/spaces-overview#managing-secrets), permits [custom requirements](/docs/hub/spaces-dependencies), and can even be managed [directly from GitHub repos](/docs/hub/spaces-github-actions). You can sign up for the beta at [hf.co/spaces](/spaces). Here are some of our favorites!
 
 - Create recipes with the help of [Chef Transformer](/spaces/flax-community/chef-transformer)
 - Transcribe speech to text with [HuBERT](https://huggingface.co/spaces/osanseviero/HUBERT)

--- a/supercharge-customer-service-with-machine-learning.md
+++ b/supercharge-customer-service-with-machine-learning.md
@@ -97,9 +97,9 @@ As a final note, we recommend making use of Hub's dataset functionality even whe
 In addition, the Hugging Face Hub offers:
 
 -   [A dataset viewer for every dataset](https://huggingface.co/datasets/amazon_reviews_multi)
--   [Easy demoing of every model using widgets](https://huggingface.co/docs/hub/main#whats-a-widget)
--   [Private and Public models](https://huggingface.co/docs/hub/adding-a-model#creating-a-repository)
--   [Git version control for repositories](https://huggingface.co/docs/hub/main#whats-a-repository)
+-   [Easy demoing of every model using widgets](https://huggingface.co/docs/hub/models-widgets)
+-   [Private and Public models](https://huggingface.co/docs/hub/repositories-settings)
+-   [Git version control for repositories](https://huggingface.co/docs/hub/repositories-getting-started)
 -   [Highest security mechanisms](https://huggingface.co/docs/hub/security)
 
 

--- a/wav2vec2-with-ngram.md
+++ b/wav2vec2-with-ngram.md
@@ -732,7 +732,7 @@ the `huggingface_hub`'s `Repository` class.
 
 More information on how to use the `huggingface_hub` to upload any
 files, please take a look at the [official
-docs](https://huggingface.co/docs/hub/how-to-upstream).
+docs](https://huggingface.co/docs/huggingface_hub/how-to-upstream).
 
 ```python
 from huggingface_hub import Repository


### PR DESCRIPTION
This fixes links to the hub docs in past blog posts to reflect the new URLs from https://github.com/huggingface/hub-docs/pull/156.