### PR TITLE
[Diffusion blog] Update notebook link

### DIFF
--- a/annotated-diffusion.md
+++ b/annotated-diffusion.md
@@ -34,7 +34,7 @@ thumbnail: /blog/assets/78_annotated-diffusion/thumbnail.png
 
 <script async defer src="https://unpkg.com/medium-zoom-element@0/dist/medium-zoom-element.min.js"></script>
 
-<a target="_blank" href="https://colab.research.google.com/drive/1GPsnxS_JW6LRv7bZNFiUtY1f4vXwu0md?usp=sharing">
+<a target="_blank" href="https://colab.research.google.com/github/huggingface/notebooks/blob/main/examples/annotated_diffusion.ipynb">
     <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 


### PR DESCRIPTION
As we just merged https://github.com/huggingface/notebooks/pull/199, we can update the notebook link for the diffusion blog.