### PR TITLE
Update gptj-sagemaker.md - update token length argument for advanced inference.

### DIFF
--- a/gptj-sagemaker.md
+++ b/gptj-sagemaker.md
@@ -268,10 +268,13 @@ tweet: Startups shouldn’t worry about how to put out fires, they should worry 
 key: hugging face
 tweet:"""
 
+prompt_token_length = len(tokenizer.encode(str(prompt), return_tensors='pt')[0])  
+
+
 predictor.predict({
 	'inputs': prompt,
   "parameters" : {
-    "max_length": int(len(prompt) + max_generated_token_length),
+    "max_length": int(prompt_token_length + max_generated_token_length),
     "temperature": float(temperature),
     "eos_token_id": int(tokenizer.convert_tokens_to_ids(end_sequence)),
     "return_full_text":False


### PR DESCRIPTION
Fixing the max_length documentation. Taking the string length doesn't reflect the true stop length of max tokens. We should be taking the length of the tokens. Taking length of string would be 296 chars vs tokens 83 chars. When I was deploying my model, this was causing me timeout issues on max token generations.