### PR TITLE
transformers.onnx typo fix

### DIFF
--- a/convert-transformers-to-onnx.md
+++ b/convert-transformers-to-onnx.md
@@ -173,7 +173,7 @@ from transformers import AutoConfig, AutoTokenizer, AutoModelForSequenceClassifi
 # load model and tokenizer
 model_id = "distilbert-base-uncased-finetuned-sst-2-english"
 feature = "sequence-classification"
-base_model = AutoModelForSequenceClassification.from_pretrained(model_id)
+model = AutoModelForSequenceClassification.from_pretrained(model_id)
 tokenizer = AutoTokenizer.from_pretrained(model_id)
 
 # load config


### PR DESCRIPTION
Fixed a typo (base_model -> model) so that the transformers.onnx script runs successfully