### PR TITLE
[DRL course] Add missing parenthesis

### DIFF
--- a/deep-rl-q-part1.md
+++ b/deep-rl-q-part1.md
@@ -391,7 +391,7 @@ If we take the same example,
 
 We can now update  \\(V(S_0)\\):
 
-New  \\(V(S_0) = V(S_0 + lr * [R_1 + gamma * V(S_1) - V(S_0)]\\)
+New  \\(V(S_0) = V(S_0) + lr * [R_1 + gamma * V(S_1) - V(S_0)]\\)
 
 New \\(V(S_0) = 0 + 0.1 * [1 + 1 * 0–0]\\)
 


### PR DESCRIPTION
Hi Team,
I've noticed one obvious typo in the https://huggingface.co/blog/deep-rl-q-part1:
![image](https://user-images.githubusercontent.com/57030016/179362723-9c090fd4-5209-4356-b1cf-3bd2f6aed4bb.png)
Not sure if this worth the PR. Please refer me to the place where we can report things like this in that case.
Thanks a lot for the course! Really awesome!
