### PR TITLE
Nesting Stable Diffusion pipeline inference under torch.autocast

### DIFF
--- a/stable_diffusion.md
+++ b/stable_diffusion.md
@@ -121,6 +121,7 @@ weights to be in float16 precision:
 
 ```python
 import torch
+from torch import autocast
 from diffusers import StableDiffusionPipeline
 
 # get your token at https://huggingface.co/settings/tokens
@@ -132,7 +133,8 @@ To run the pipeline, simply define the prompt and call `pipe`:
 ```python
 prompt = "a photograph of an astronaut riding a horse"
 
-image = pipe(prompt)["sample"][0]
+with autocast("cuda"):
+    image = pipe(prompt)["sample"][0]
 
 # you can save the image with
 # image.save(f"astronaut_rides_horse.png")


### PR DESCRIPTION
Ideally, all the other inferences within the blog should be under it, however, I wanted to double-check if that was intentional before fixing it everywhere else on the blog.

Please feel free to close this if this is not the case. Happy to make more changes.

cc: @anton-l 

