### PR TITLE
Fix the blogpost link in the decision transformer notebook

### DIFF
--- a/notebooks/101_train-decision-transformers.ipynb
+++ b/notebooks/101_train-decision-transformers.ipynb
@@ -56,7 +56,7 @@
         "### Prerequisites 🏗️\n",
         "Before diving into the notebook, you need to:\n",
         "\n",
-        "🔲 📚 [Read the tutorial](https://huggingface.co/blog/decision-transformers-train)"
+        "🔲 📚 [Read the tutorial](https://huggingface.co/blog/train-decision-transformers)"
       ]
     },
     {


### PR DESCRIPTION
The notebook/colab currently points to https://huggingface.co/blog/decision-transformers-train which does not exist. However, https://huggingface.co/blog/train-decision-transformers does exist, and it seems like that's what was intended, so I switched the link so that it works.