### PR TITLE
[SegFormer] Update blog

### DIFF
--- a/fine-tune-segformer.md
+++ b/fine-tune-segformer.md
@@ -338,7 +338,9 @@ def compute_metrics(eval_pred):
     ).argmax(dim=1)
 
     pred_labels = logits_tensor.detach().cpu().numpy()
-    metrics = metric.compute(
+    # currently using _compute instead of compute
+    # see this issue for more info: https://github.com/huggingface/evaluate/pull/328#issuecomment-1286866576
+    metrics = metric._compute(
             predictions=pred_labels,
             references=labels,
             num_labels=len(id2label),

--- a/fine-tune-segformer.md
+++ b/fine-tune-segformer.md
@@ -56,7 +56,6 @@ The installation of `git-lfs` might be different on your system. Note that Googl
 
 ```bash
 pip install -q transformers datasets evaluate segments-ai
-pip install -q 
 apt-get install git-lfs
 git lfs install
 huggingface-cli login
@@ -313,7 +312,7 @@ training_args = TrainingArguments(
 )
 ```
 
-Next, we'll define a function that computes the evaluation metric we want to work with. Because we're doing semantic segmentation, we'll use the mean Intersection over Union (mIoU), directly accessible in the [`evaluate` library](https://huggingface.co/docs/evaluate/index). IoU represents the overlap of segmentation masks. Mean IoU is the average of the IoU of all semantic classes. Take a look at [this blogpost](https://www.jeremyjordan.me/evaluating-image-segmentation-models/) for an overview of evaluation metrics for image segmentation.
+Next, we'll define a function that computes the evaluation metric we want to work with. Because we're doing semantic segmentation, we'll use the [mean Intersection over Union (mIoU)](https://huggingface.co/spaces/evaluate-metric/mean_iou), directly accessible in the [`evaluate` library](https://huggingface.co/docs/evaluate/index). IoU represents the overlap of segmentation masks. Mean IoU is the average of the IoU of all semantic classes. Take a look at [this blogpost](https://www.jeremyjordan.me/evaluating-image-segmentation-models/) for an overview of evaluation metrics for image segmentation.
 
 Because our model outputs logits with dimensions height/4 and width/4, we have to upscale them before we can compute the mIoU.
 


### PR DESCRIPTION
This PR updates the "Fine-tuning a Semantic Segmentation model" blog:

- use of `evaluate` instead of `datasets` for metrics
- use of `hf_hub_download`

It also updates the link to a new Colab notebook.