### PR TITLE
Fix update on github link for evaluating-llm-bias

### DIFF
--- a/evaluating-llm-bias.md
+++ b/evaluating-llm-bias.md
@@ -7,7 +7,7 @@ thumbnail: /blog/assets/112_evaluating-llm-bias/thumbnail.png
 
 <div class="blog-metadata">
     <small>Published October 24th, 2022.</small>
-    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/bias-evaluating-llm-bias.md">
+    <a target="_blank" class="btn no-underline text-sm mb-5 font-sans" href="https://github.com/huggingface/blog/blob/main/evaluating-llm-bias.md">
         Update on GitHub
     </a>
 </div>


### PR DESCRIPTION
Found a broken link in url:
bias-evaluating-llm-bias -> evaluating-llm-bias