### PR TITLE
update all references of examples/seq2seq -> examples/legacy/seq2seq

### DIFF
--- a/sagemaker-distributed-training-seq2seq.md
+++ b/sagemaker-distributed-training-seq2seq.md
@@ -124,7 +124,7 @@ print(f"S3 bucket used for storing artifacts: {sess.default_bucket()}")
 
 # Choose 🤗 Transformers `examples/` script
 
-The [🤗 Transformers repository](https://github.com/huggingface/transformers/tree/master/examples) contains several `examples/`scripts for fine-tuning models on tasks from `language-modeling` to `token-classification`. In our case, we are using the `run_summarization.py` from the `seq2seq/` examples. 
+The [🤗 Transformers repository](https://github.com/huggingface/transformers/tree/master/examples) contains several `examples/`scripts for fine-tuning models on tasks from `language-modeling` to `token-classification`. In our case, we are using the `run_summarization.py` from the `legacy/seq2seq/` examples. 
 
 ***Note**: you can use this tutorial as-is to train your model on a different examples script.*
 
@@ -179,7 +179,7 @@ from sagemaker.huggingface import HuggingFace
 # create the Estimator
 huggingface_estimator = HuggingFace(
       entry_point='run_summarization.py', # script
-      source_dir='./examples/seq2seq', # relative path to example
+      source_dir='./examples/legacy/seq2seq', # relative path to example
       git_config=git_config,
       instance_type='ml.p3dn.24xlarge',
       instance_count=2,

--- a/sagemaker-distributed-training-seq2seq.md
+++ b/sagemaker-distributed-training-seq2seq.md
@@ -142,7 +142,7 @@ git_config = {'repo': 'https://github.com/philschmid/transformers.git','branch':
 
 ## Configure distributed training and hyperparameters
 
-Next, we will define our `hyperparameters` and configure our distributed training strategy. As hyperparameter, we can define any [Seq2SeqTrainingArguments](https://huggingface.co/transformers/main_classes/trainer.html#seq2seqtrainingarguments) and the ones defined in [run_summarization.py](https://github.com/huggingface/transformers/tree/master/examples/seq2seq#sequence-to-sequence-training-and-evaluation). 
+Next, we will define our `hyperparameters` and configure our distributed training strategy. As hyperparameter, we can define any [Seq2SeqTrainingArguments](https://huggingface.co/transformers/main_classes/trainer.html#seq2seqtrainingarguments) and the ones defined in [run_summarization.py](https://github.com/huggingface/transformers/tree/main/examples/legacy/seq2seq#sequence-to-sequence-training-and-evaluation). 
 
 ```python
 # hyperparameters, which are passed into the training job


### PR DESCRIPTION
Hi, while going through the blog I found more instances of the old path, including one in the hf estimator code snippet.