### PR TITLE
Core ML: make download code more robust

### DIFF
--- a/diffusers-coreml.md
+++ b/diffusers-coreml.md
@@ -89,28 +89,43 @@ This is how you'd download the `original` attention variant from the Hub:
 
 ```Python
 from huggingface_hub import snapshot_download
+from huggingface_hub.file_download import repo_folder_name
+from pathlib import Path
+import shutil
 
 repo_id = "apple/coreml-stable-diffusion-v1-4"
 variant = "original/packages"
 
-downloaded = snapshot_download(repo_id, allow_patterns=f"{variant}/*")
+def download_model(repo_id, variant, output_dir):
+    destination = Path(output_dir) / (repo_id.split("/")[-1] + "_" + variant.replace("/", "_"))
+    if destination.exists():
+        raise Exception(f"Model already exists at {destination}")
+    
+    # Download and copy without symlinks
+    downloaded = snapshot_download(repo_id, allow_patterns=f"{variant}/*", cache_dir=output_dir)
+    downloaded_bundle = Path(downloaded) / variant
+    shutil.copytree(downloaded_bundle, destination)
+
+    # Remove all downloaded files
+    cache_folder = Path(output_dir) / repo_folder_name(repo_id=repo_id, repo_type="model")
+    shutil.rmtree(cache_folder)
+    return destination
+
+model_path = download_model(repo_id, variant, output_dir="./models")
+print(f"Model downloaded at {model_path}")
 ```
 
-Note how the `variant` string reflects the tree structure shown above. Also note that you can download the models to a folder of your choosing by using the additional argument `cache_dir`, for example:
-
-```Python
-downloaded = snapshot_download(repo_id, allow_patterns=f"{variant}/*", cache_dir="./models")
-```
+The code above will place the downloaded model snapshot inside the directory you specify (`models`, in this case).
 
 ### Inference
 
 Once you have downloaded a snapshot of the model, the easiest way to run inference would be to use Apple's Python script.
 
 ```shell
-python -m python_coreml_stable_diffusion.pipeline --prompt "a photo of an astronaut riding a horse on mars" -i <output-mlpackages-directory> -o </path/to/output/image> --compute-unit ALL --seed 93
+python -m python_coreml_stable_diffusion.pipeline --prompt "a photo of an astronaut riding a horse on mars" -i models/coreml-stable-diffusion-v1-4_original_packages -o </path/to/output/image> --compute-unit ALL --seed 93
 ```
 
-`<output-mlpackages-directory>` should point to the snaphost you downloaded in the step above, and `--compute-unit` indicates the hardware you want to allow for inference. It must be one of the following options: `ALL`, `CPU_AND_GPU`, `CPU_ONLY`, `CPU_AND_NE`. You may also provide an optional output path, and a seed for reproducibility.
+`<output-mlpackages-directory>` should point to the checkpoint you downloaded in the step above, and `--compute-unit` indicates the hardware you want to allow for inference. It must be one of the following options: `ALL`, `CPU_AND_GPU`, `CPU_ONLY`, `CPU_AND_NE`. You may also provide an optional output path, and a seed for reproducibility.
 
 ## Core ML inference in Swift
 
@@ -118,15 +133,34 @@ Running inference in Swift is slightly faster than in Python, because the models
 
 ### Download
 
-To run inference in Swift on your Mac, you need one of the `compiled` checkpoint versions. We recommend you download them locally using Python code similar to the one we showed above:
+To run inference in Swift on your Mac, you need one of the `compiled` checkpoint versions. We recommend you download them locally using Python code similar to the one we showed above, but using one of the `compiled` variants:
 
 ```Python
 from huggingface_hub import snapshot_download
+from huggingface_hub.file_download import repo_folder_name
+from pathlib import Path
+import shutil
 
 repo_id = "apple/coreml-stable-diffusion-v1-4"
 variant = "original/compiled"
 
-downloaded = snapshot_download(repo_id, allow_patterns=f"{variant}/*")
+def download_model(repo_id, variant, output_dir):
+    destination = Path(output_dir) / (repo_id.split("/")[-1] + "_" + variant.replace("/", "_"))
+    if destination.exists():
+        raise Exception(f"Model already exists at {destination}")
+    
+    # Download and copy without symlinks
+    downloaded = snapshot_download(repo_id, allow_patterns=f"{variant}/*", cache_dir=output_dir)
+    downloaded_bundle = Path(downloaded) / variant
+    shutil.copytree(downloaded_bundle, destination)
+
+    # Remove all downloaded files
+    cache_folder = Path(output_dir) / repo_folder_name(repo_id=repo_id, repo_type="model")
+    shutil.rmtree(cache_folder)
+    return destination
+
+model_path = download_model(repo_id, variant, output_dir="./models")
+print(f"Model downloaded at {model_path}")
 ```
 
 ### Inference


### PR DESCRIPTION
- The directory that has to be used for inference is nested inside the snapshot folder structure.
- `coremltools` seems to not play nice with symlinks (!?).

This version uses `shutil.copytree` to undo the symlinks and removes all the downloaded artifacts afterwards.