### PR TITLE
Typo: Add missing ' ' in  codeparrot post on 'gpt-large'

### DIFF
--- a/codeparrot.md
+++ b/codeparrot.md
@@ -80,7 +80,7 @@ config_kwargs = {"vocab_size": len(tokenizer),
                  "reorder_and_upcast_attn": True}
 
 # Load model with config and push to hub
-config = AutoConfig.from_pretrained(gpt2-large, **config_kwargs)
+config = AutoConfig.from_pretrained('gpt2-large', **config_kwargs)
 model = AutoModelForCausalLM.from_config(config)
 model.save_pretrained(args.model_name, push_to_hub=args.push_to_hub)
 ```


### PR DESCRIPTION
### Description
Based on the [from_pretrained](https://huggingface.co/gpt2-large) method, you need to pass the path of the model which is 'gpt2-large' not the variable of gpt2-large which has no reference.

### Fix
The ' ' was missing.

### Solution
Add missing ' '