### PR TITLE
Use visual_prompt in CLIPSegProcessor

### DIFF
--- a/clipseg-zero-shot.md
+++ b/clipseg-zero-shot.md
@@ -173,11 +173,10 @@ We can now process the input image and prompt image and input them to
 the model.
 
 ```python
-encoded_image = processor(images=[image], return_tensors="pt")
-encoded_prompt = processor(images=[prompt], return_tensors="pt")
+inputs = processor(images=image, visual_prompt=prompt, return_tensors="pt")
 # predict
 with torch.no_grad():
-  outputs = model(**encoded_image, conditional_pixel_values=encoded_prompt.pixel_values)
+  outputs = model(**inputs)
 preds = outputs.logits.unsqueeze(1)
 preds = torch.transpose(preds, 0, 1)
 ```
@@ -209,10 +208,10 @@ alternative_prompt
 </figure>
 
 ```python
-encoded_alternative_prompt = processor(images=[alternative_prompt], return_tensors="pt")
+inputs = processor(images=image, visual_prompt=alternative_prompt, return_tensors="pt")
 # predict
 with torch.no_grad():
-  outputs = model(**encoded_image, conditional_pixel_values=encoded_alternative_prompt.pixel_values)
+  outputs = model(**inputs)
 preds = outputs.logits.unsqueeze(1)
 preds = torch.transpose(preds, 0, 1)
 ```

--- a/notebooks/123_clipseg-zero-shot.ipynb
+++ b/notebooks/123_clipseg-zero-shot.ipynb
@@ -206,11 +206,10 @@
       },
       "outputs": [],
       "source": [
-        "encoded_image = processor(images=[image], return_tensors=\"pt\")\n",
-        "encoded_prompt = processor(images=[prompt], return_tensors=\"pt\")\n",
+        "inputs = processor(images=image, visual_prompt=prompt, return_tensors=\"pt\")\n",
         "# predict\n",
         "with torch.no_grad():\n",
-        "  outputs = model(**encoded_image, conditional_pixel_values=encoded_prompt.pixel_values)\n",
+        "  outputs = model(**inputs)\n",
         "preds = outputs.logits.unsqueeze(1)\n",
         "preds = torch.transpose(preds, 0, 1)"
       ]
@@ -259,10 +258,10 @@
       },
       "outputs": [],
       "source": [
-        "encoded_alternative_prompt = processor(images=[alternative_prompt], return_tensors=\"pt\")\n",
+        "inputs = processor(images=image, visual_prompt=alternative_prompt, return_tensors=\"pt\")\n",
         "# predict\n",
         "with torch.no_grad():\n",
-        "  outputs = model(**encoded_image, conditional_pixel_values=encoded_alternative_prompt.pixel_values)\n",
+        "  outputs = model(**inputs)\n",
         "preds = outputs.logits.unsqueeze(1)\n",
         "preds = torch.transpose(preds, 0, 1)"
       ]


### PR DESCRIPTION
This PR adds the new syntax for the `CLIPSegProcessor` introduced by [https://github.com/huggingface/transformers/pull/20816](https://github.com/huggingface/transformers/pull/20816).

We should probably only merge this when a new release of Transformers is created, right? @NielsRogge 