### PR TITLE
The previous code does not work with the latest version

### DIFF
--- a/warm-starting-encoder-decoder.md
+++ b/warm-starting-encoder-decoder.md
@@ -1211,8 +1211,6 @@ def process_data_to_model_inputs(batch):
 
   batch["input_ids"] = inputs.input_ids
   batch["attention_mask"] = inputs.attention_mask
-  batch["decoder_input_ids"] = outputs.input_ids
-  batch["decoder_attention_mask"] = outputs.attention_mask
   batch["labels"] = outputs.input_ids.copy()
 
   # because BERT automatically shifts the labels, the labels correspond exactly to `decoder_input_ids`. 
@@ -1266,7 +1264,7 @@ convert the data to PyTorch Tensors to be trained on GPU.
 
 ```python
 train_data.set_format(
-    type="torch", columns=["input_ids", "attention_mask", "decoder_input_ids", "decoder_attention_mask", "labels"],
+    type="torch", columns=["input_ids", "attention_mask", "labels"],
 )
 ```
 
@@ -1301,7 +1299,7 @@ and, finally, the validation data is also converted to PyTorch tensors.
 
 ```python
 val_data.set_format(
-    type="torch", columns=["input_ids", "attention_mask", "decoder_input_ids", "decoder_attention_mask", "labels"],
+    type="torch", columns=["input_ids", "attention_mask", "labels"],
 )
 ```
 


### PR DESCRIPTION
The previous code doesn't work with the latest version of transformers. It generated random text when we provide the model with deocoder input_id's and attention mask. Seems like the latest version implements shift right on input_ids automatically. Please refer to the link for clarification : https://github.com/huggingface/transformers/issues/18958 

The current version works for me with codebert as input and gpt2 as output. Thank you.