### PR TITLE
Remove Colab link

### DIFF
--- a/mask2former.md
+++ b/mask2former.md
@@ -40,10 +40,6 @@ thumbnail: /blog/assets/127_mask2former/thumbnail.png
 
 <script async defer src="https://unpkg.com/medium-zoom-element@0/dist/medium-zoom-element.min.js"></script>
 
-<a target="_blank" href="https://colab.research.google.com/drive/1MdkavsjGHYcuGyjmsf9wmeAK3WvtYLty?usp=sharing">
-    <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
-</a>
-
 **This guide introduces Mask2Former and OneFormer, 2 state-of-the-art neural networks for image segmentation. The models are now available in [`🤗 transformers`](https://huggingface.co/transformers), an open-source library that offers easy-to-use implementations of state-of-the-art models. Along the way, you'll learn about the difference between the various forms of image segmentation.**
 
 ## Image segmentation


### PR DESCRIPTION
This PR removes the Colab link of the Mask2Former blog, which links to an older blog post