### PR TITLE
Dreambooth fix co-author: @NineOfNein / Valentine Kozin

### DIFF
--- a/dreambooth.md
+++ b/dreambooth.md
@@ -4,7 +4,7 @@ thumbnail: /blog/assets/sd_dreambooth_training/thumbnail.jpg
 authors:
 - user: valhalla
 - user: pcuenq
-- user: NineOfNein
+- user: who_is_this
   guest: true
 ---
 

--- a/dreambooth.md
+++ b/dreambooth.md
@@ -4,7 +4,7 @@ thumbnail: /blog/assets/sd_dreambooth_training/thumbnail.jpg
 authors:
 - user: valhalla
 - user: pcuenq
-- user: who_is_this
+- user: 9of9
   guest: true
 ---
 


### PR DESCRIPTION
Hi @patil-suraj @pcuenca 

We just moved to a more structured data for co-authors of blog posts (linking to their HF profile) and this is one user i haven't been able to find the HF user account for: `NineOfNein / Valentine Kozin`

Would you be able to ask them for their HF user name, which will be linked here? or even tag them here if you know their GitHub (haven't been able to find it either)

Thanks a lot!!

<img width="1053" alt="Screenshot 2023-02-03 at 16 43 25" src="https://user-images.githubusercontent.com/326577/216645643-6960b9dd-225a-488c-b7c1-6c5d1bce13ce.png">
