### PR TITLE
Update cv_state.md by Losing Lena

### DIFF
--- a/cv_state.md
+++ b/cv_state.md
@@ -73,10 +73,10 @@ The interface remains the same even for tasks like visual question-answering:
 from transformers import pipeline
 
 oracle = pipeline(model="dandelin/vilt-b32-finetuned-vqa")
-image_url = "https://huggingface.co/datasets/Narsil/image_dummy/raw/main/lena.png"
+image_url = "https://huggingface.co/datasets/mishig/sample_images/resolve/main/tiger.jpg"
 
-oracle(question="What is she wearing?", image=image_url, top_k=1)
-# [{'score': 0.948, 'answer': 'hat'}]
+oracle(question="What's the animal doing?", image=image_url, top_k=1)
+# [{'score': 0.778620, 'answer': 'laying down'}]
 ```
 
 ## Training your own models


### PR DESCRIPTION
Replaced the Lena image & visual QA example with the Tiger image from dandelin/vilt-b32-finetuned-vqa. Usage of the Lena image has long been scaled out in CV research, and I see no reason to continue to utilize it in HuggingFace official blog posts. I was actually very surprised to see it used here, as there really is no need.

As Dianne P. O'leary wrote: 
> Suggestive pictures used in lectures on image processing ... convey the message that the lecturer caters to the males only. For example, it is amazing that the "Lena" pin-up image is still used as an example in courses and published as a test image in journals today.

The actual person in the Lena image, Forsén, has stated in the 2019 documentary film Losing Lena,
> I retired from modeling a long time ago. It’s time I retired from tech, too... Let's commit to losing me.


Further reading if you need more convincing:
 * https://en.wikipedia.org/wiki/Lenna#Criticism
 * https://pursuit.unimelb.edu.au/articles/it-s-time-to-retire-lena-from-computer-science
 * https://womenlovetech.com/losing-lena-why-we-need-to-remove-one-image-and-end-techs-original-sin/
 * An amazing video on the topic: https://www.youtube.com/watch?v=yCdwm2vo09I