### PR TITLE
Fix example code in 3dmoljs blog post

### DIFF
--- a/spaces_3dmoljs.md
+++ b/spaces_3dmoljs.md
@@ -115,6 +115,7 @@ The `head` of our returned document needs to load 3Dmol.js (which in turn also l
         background-image:None;
     }
     </style>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.3/jquery.min.js" integrity="sha512-STof4xm1wgkfm7heWqFJVn58Hm3EtS31XFaagaa8VMReCXAkQnJZ+jEy8PCC/iT18dFy95WcExNHFTqLyp72eQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://3Dmol.csb.pitt.edu/build/3Dmol-min.js"></script>
 </head>
 ```


### PR DESCRIPTION
3dmol.js received a major rewrite that removed JQuery from the bundle. Readding JQuery to make the demo work again.