### PR TITLE
Update Whisper FT Blog

### DIFF
--- a/fine-tune-whisper.md
+++ b/fine-tune-whisper.md
@@ -135,13 +135,6 @@ strong performance in this language.
 
 ### Prepare Environment
 
-First, we need to update the Unix package `ffmpeg` to version 4:
-```bash
-!add-apt-repository -y ppa:jonathonf/ffmpeg-4
-!apt update
-!apt install -y ffmpeg
-```
-
 We'll employ several popular Python packages to fine-tune the Whisper model.
 We'll use `datasets` to download and prepare our training data and 
 `transformers` to load and train our Whisper model. We'll also require


### PR DESCRIPTION
Google Colab upgraded to Ubuntu v20 which ships with the latest versions of `ffmpeg` => no need to bump the `ffmpeg` version to 4.27 anymore.