### PR TITLE
Change controlnet title to fast

### DIFF
--- a/controlnet.md
+++ b/controlnet.md
@@ -7,7 +7,7 @@ authors:
 - user: patrickvonplaten
 ---
 
-# ControlNet in 🧨 Diffusers
+# Ultra fast ControlNet with 🧨 Diffusers
 
 <!-- {blog_metadata} -->
 <!-- {authors} -->


### PR DESCRIPTION
Our approach is 3-4x faster than the original one. As the community is exposed with controlnet, just "controlnet with diffusers" would excite only those who care about diffusers. Mentioning the speed can attract those that don't care about diffusers but care about speed 