### PR TITLE
Fixed a typo in the section B of the file

### DIFF
--- a/notebooks/95_Training_Sentence_Transformers.ipynb
+++ b/notebooks/95_Training_Sentence_Transformers.ipynb
@@ -8186,7 +8186,7 @@
     {
       "cell_type": "code",
       "source": [
-        "model.fit(train_objectives=[(train_dataloaderB, train_lossB)],\n",
+        "modelB.fit(train_objectives=[(train_dataloaderB, train_lossB)],\n",
         "          epochs=num_epochsB,\n",
         "          warmup_steps=warmup_stepsB) "
       ],

--- a/notebooks/95_Training_Sentence_Transformers.ipynb
+++ b/notebooks/95_Training_Sentence_Transformers.ipynb
@@ -8199,7 +8199,7 @@
     {
       "cell_type": "code",
       "source": [
-        "model.save_to_hub(\n",
+        "modelB.save_to_hub(\n",
         "    \"distilroberta-base-sentence-transformer\", \n",
         "    organization=\"embedding-data\",\n",
         "    train_datasets=[\"embedding-data/sentence-compression\"],\n",


### PR DESCRIPTION
The type was referencing to an older model variable instead of modelB which is the model the section was intending to train.