### PR TITLE
[Time series] informer blog fix latex

### DIFF
--- a/_tags.yml
+++ b/_tags.yml
@@ -36,3 +36,6 @@
 
 - value: game-dev
   label: Game Development
+
+- value: time-series
+  label: Time Series

--- a/informer.md
+++ b/informer.md
@@ -186,7 +186,7 @@ As we will show, GluonTS will be used for transforming the data to create featur
 
 ## Load Dataset
 
-In this blog post, we'll use the `traffic_hourly` dataset, which is available on the [Hugging Face Hub](https://huggingface.co/datasets/monash_tsf). This dataset contains the San Francisco Traffic dataset used by [Lai et al. (2017)](https://arxiv.org/abs/1703.07015). It contains 862 hourly time series showing the road occupancy rates in the range $[0, 1]$ on the San Francisco Bay area freeways from 2015 to 2016.
+In this blog post, we'll use the `traffic_hourly` dataset, which is available on the [Hugging Face Hub](https://huggingface.co/datasets/monash_tsf). This dataset contains the San Francisco Traffic dataset used by [Lai et al. (2017)](https://arxiv.org/abs/1703.07015). It contains 862 hourly time series showing the road occupancy rates in the range \\([0, 1]\\) on the San Francisco Bay area freeways from 2015 to 2016.
 
 This dataset is part of the [Monash Time Series Forecasting](https://forecastingdata.org/) repository, a collection of time series datasets from a number of domains. It can be viewed as the [GLUE benchmark](https://gluebenchmark.com/) of time series forecasting.
 


### PR DESCRIPTION
use `\\( \\)` for inline latex.

cc @NielsRogge 