### PR TITLE
Update [typo/wording] accelerate-large-models.md

### DIFF
--- a/accelerate-large-models.md
+++ b/accelerate-large-models.md
@@ -104,7 +104,7 @@ Since we know the shape of each weight, we can however know how much memory they
 
 ## Computing a device map
 
-Before we start loading the pretrained weights, we will need to know where we want to put them. This way we can free the CPU RAM each time we have put a weight in its right place. This can be done with the empty model on the meta device, since we only need to know the shape of each tensor and its dtype to be compute how much space it will take in memory.
+Before we start loading the pretrained weights, we will need to know where we want to put them. This way we can free the CPU RAM each time we have put a weight in its right place. This can be done with the empty model on the meta device, since we only need to know the shape of each tensor and its dtype to compute how much space it will take in memory.
 
 Accelerate provides a function to automatically determine a *device map* from an empty model. It will try to maximize the use of all available GPUs, then CPU RAM, and finally flag the weights that don't fit for disk offload. Let's have a look using [OPT-13b](https://huggingface.co/facebook/opt-13b).
 


### PR DESCRIPTION
remove extra "be" from 'Computing a device map' section