### PR TITLE
Fix 8-bit Matrix Multiplication example dimensions

### DIFF
--- a/hf-bitsandbytes-integration.md
+++ b/hf-bitsandbytes-integration.md
@@ -291,7 +291,7 @@ Which is close enough to the original FP16 values (2 print outs up)!
 6. Now you can safely infer using your model by making sure your input is on the correct GPU and is in FP16:
 
 ```py
-input_ = torch.randn(64, dtype=torch.float16)
+input_ = torch.randn((1, 64), dtype=torch.float16)
 hidden_states = int8_model(input_.to(torch.device('cuda', 0)))
 ```
 


### PR DESCRIPTION
Old code
`input_ = torch.randn(64, dtype=torch.float16)`
produced error. See this [discuss](https://discuss.huggingface.co/t/the-quantization-code-in-the-gentle-introduction-to-8-bit-matrix-multiplication-for-transformers-blog-post-yields-error/38060)

So I fixed dimensions to correct one
`input_ = torch.randn((1, 64), dtype=torch.float16)`
