### PR TITLE
Update 4bit-transformers-bitsandbytes.md

### DIFF
--- a/4bit-transformers-bitsandbytes.md
+++ b/4bit-transformers-bitsandbytes.md
@@ -62,7 +62,7 @@ It has been empirically proven that the E4M3 is best suited for the forward pass
 
 ### FP4 precision in a few words
 
-The sign bit represents the sign (+/-), the exponent bits a base two to the power of the integer represented by the bits (e.g. `2^{010} = 2^{2} = 4`), and the fraction or mantissa is the sum of powers of negative two which are “active” for each bit that is “1”. If a bit is “0” the fraction remains unchanged for that power of `2^-i` where i is the position of the bit in the bit-sequence. For example, for mantissa bits 1010 we have `(0 + 2^-1 + 0 + 2^-3) = (0.5 + 0.125) = 0.625`. To get a value, we add *1* to the fraction and multiply all results together, for example, with 2 exponent bits and one mantissa bit the representations 1101 would be:
+The sign bit represents the sign (+/-), the exponent bits a base two to the power of the integer represented by the bits (e.g. `2^{010} = 2^{2} = 4`), and the fraction or mantissa is the sum of powers of negative two which are “active” for each bit that is “1”. If a bit is “0” the fraction remains unchanged for that power of `2^-i` where i is the position of the bit in the bit-sequence. For example, for mantissa bits 1010 we have `(2^-1 + 0 + 2^-3 + 0) = (0.5 + 0.125) = 0.625`. To get a value, we add *1* to the fraction and multiply all results together, for example, with 2 exponent bits and one mantissa bit the representations 1101 would be:
 
 `-1 * 2^(2) * (1 + 2^-1) = -1 * 4 * 1.5 = -6`
 


### PR DESCRIPTION
The value ends up being the same but this maybe clearer for the reader:  mantisaa bits 1010 we have `(2^-1 + 0 + 2^-3 + 0) = (0.5 + 0.125) = 0.625`  instead of 
mantisaa bits 1010 we have `(0 + 2^-1 + 0 +  2^-3 ) = (0.5 + 0.125) = 0.625`  Since the mantissa bits are read from left to right and the first bit is 1 it should correspond to 2^-1 and not 0