### PR TITLE
Fix relative links in sagemaker-huggingface-llm.md

### DIFF
--- a/sagemaker-huggingface-llm.md
+++ b/sagemaker-huggingface-llm.md
@@ -10,8 +10,8 @@ authors:
 <!-- {blog_metadata} -->
 <!-- {authors} -->
 
-This is an example on how to deploy the open-source LLMs, like [BLOOM](bigscience/bloom) to Amazon SageMaker for inference using the new Hugging Face LLM Inference Container.
-We will deploy the 12B [Pythia Open Assistant Model](OpenAssistant/pythia-12b-sft-v8-7k-steps), an open-source Chat LLM trained with the Open Assistant dataset.
+This is an example on how to deploy the open-source LLMs, like [BLOOM](https://huggingface.co/bigscience/bloom) to Amazon SageMaker for inference using the new Hugging Face LLM Inference Container.
+We will deploy the 12B [Pythia Open Assistant Model](https://huggingface.co/OpenAssistant/pythia-12b-sft-v8-7k-steps), an open-source Chat LLM trained with the Open Assistant dataset.
 
 The example covers:
 


### PR DESCRIPTION
Having these as relative paths adds a `/blog/` in the url which breaks these links. Changing to absolute paths fixes the problem

/cc @philschmid 