### PR TITLE
Sync DuckDB title between thumbnail page and post page

### DIFF
--- a/_blog.yml
+++ b/_blog.yml
@@ -2280,7 +2280,7 @@
     - partnerships
 
 - local: hub-duckdb
-  title: "DuckDB: analyze 50,000+ datasets stored on the Hugging Face Hub"
+  title: "DuckDB: run SQL queries on 50,000+ datasets on the Hugging Face Hub"
   author: stevhliu
   thumbnail: /blog/assets/hub_duckdb/hub_duckdb.png
   date: June 7, 2023


### PR DESCRIPTION
Just in case it was not intentional to have different titles