### PR TITLE
RLHF blogpost markdown fixes

### DIFF
--- a/rlhf.md
+++ b/rlhf.md
@@ -88,7 +88,8 @@ Finally, the **update rule** is the parameter update from PPO that maximizes the
 <p align="center">
     <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/blog/rlhf/rlhf.png" width="650" />
 </p>
-_Technical detail note: The above diagram makes it look like both models generate different responses for the same prompt, but what really happens is that the RL policy generates text, and that text is fed into the initial model to produce its relative probabilities for the KL penalty._
+
+_Technical detail note: The above diagram makes it look like both models generate different responses for the same prompt, but what really happens is that the RL policy generates text, and that text is fed into the initial model to produce its relative probabilities for the KL penalty_.
 
 Optionally, RLHF can continue from this point by iteratively updating the reward model and the policy together. As the RL policy updates, users can continue ranking these outputs versus the model's earlier versions. Most papers have yet to discuss implementing this operation, as the deployment mode needed to collect this type of data only works for dialogue agents with access to an engaged user base. Anthropic discusses this option as *Iterated Online RLHF* (see the original [paper](https://arxiv.org/abs/2204.05862)), where iterations of the policy are included in the ELO ranking system across models. This introduces complex dynamics of the policy and reward model evolving, which represents a complex and open research question.
 
@@ -163,6 +164,8 @@ BibTeX citation:
 }
 ```
 
-*Thanks to [Robert Kirk](https://robertkirk.github.io/) for fixing some factual errors regarding specific implementations of RLHF. Thanks to [Peter Stone](https://www.cs.utexas.edu/~pstone/), [Khanh X. Nguyen](https://machineslearner.com/) and [Yoav Artzi](https://yoavartzi.com/) for helping expand the related works further into history. *
+*Thanks to [Robert Kirk](https://robertkirk.github.io/) for fixing some factual errors regarding specific implementations of RLHF. Thanks to [Peter Stone](https://www.cs.utexas.edu/~pstone/), [Khanh X. Nguyen](https://machineslearner.com/) and [Yoav Artzi](https://yoavartzi.com/) for helping expand the related works further into history.*
+
 *Thanks to Stas Bekman for fixing some typos or confusing phrases.*
+
 *Thanks to [Igor Kotenkov](https://www.linkedin.com/in/seeall/) for pointing out a technical error in the KL-penalty term of the RLHF procedure, its diagram, and textual description.*


### PR DESCRIPTION
Hi, following #1208 , it seems I messed up with Markdown (see below, first and last characters in every block, `_` and `*`)
<img width="1006" alt="image" src="https://github.com/huggingface/blog/assets/26546178/e4a58e92-ad8d-4052-bea9-0e9eb238f153">
<img width="940" alt="image" src="https://github.com/huggingface/blog/assets/26546178/722bdcd0-f390-4a16-ad15-2a3a2760aafc">

This PR should fix that