### PR TITLE
Update "How to deploy LLM" blog post to use `huggingface_hub` in example 

### DIFF
--- a/inference-endpoints-llm.md
+++ b/inference-endpoints-llm.md
@@ -95,7 +95,7 @@ First, you need to install the `huggingface_hub` library:
 pip install -U huggingface_hub
 ```
 
-We can create a `InferenceClient` providing our endpoint URL and credential alongside the hyperparameter we want to use
+We can create a `InferenceClient` providing our endpoint URL and credential alongside the hyperparameters we want to use
 
 ```python
 from huggingface_hub import InferenceClient

--- a/inference-endpoints-llm.md
+++ b/inference-endpoints-llm.md
@@ -89,23 +89,23 @@ Requesting and generating text with LLMs can be a time-consuming and iterative p
 
 ### Streaming requests with Python
 
-First, you need to install the `text-generation` client
+First, you need to install the `huggingface_hub` library:
 
 ```python
-pip install text-generation
+pip install -U huggingface_hub
 ```
 
-We can create a `Client` providing our endpoint URL and credential alongside the hyperparameter we want to use
+We can create a `InferenceClient` providing our endpoint URL and credential alongside the hyperparameter we want to use
 
 ```python
-from text_generation import Client
+from huggingface_hub import InferenceClient
 
 # HF Inference Endpoints parameter
 endpoint_url = "https://YOUR_ENDPOINT.endpoints.huggingface.cloud"
 hf_token = "hf_YOUR_TOKEN"
 
 # Streaming Client
-client = Client(endpoint_url, headers={"Authorization": f"Bearer {hf_token}"})
+client = InferenceClient(endpoint_url, token=hf_token)
 
 # generation parameter
 gen_kwargs = dict(
@@ -119,7 +119,8 @@ gen_kwargs = dict(
 # prompt
 prompt = "What can you do in Nuremberg, Germany? Give me 3 Tips"
 
-stream = client.generate_stream(prompt, **gen_kwargs)
+stream = client.text_generation(prompt, stream=True, details=True, **gen_kwargs)
+
 # yield each generated token
 for r in stream:
     # skip special tokens


### PR DESCRIPTION
Related to https://github.com/huggingface/blog/pull/1286#discussion_r1252786764.

Goal is to showcase `huggingface_hub.InferenceClient` in order to get more visibility/usage on a single client library. Implementation is (almost) the same as `text-generation` cc @OlivierDehaene @julien-c @philschmid 

`InferenceClient` has been released in `huggingface_hub==0.16` today (see [release notes](https://github.com/huggingface/huggingface_hub/releases/tag/v0.16.2)). I tested the modification in this PR by creating a temporary Inference Endpoint.

---

Worth mentioning that we can have a simpler example here. If `details=False` is passed (default), tokens are yielded as `str` directly. I still think that showing how to use `details=True` in the blog post is better.

```py
stream = client.text_generation(prompt, stream=True, **gen_kwargs)

# yield each generated token
for token in stream:

    # yield the generated token
    print(token, end="")
    # yield token
```