### PR TITLE
Use gradio light theme in blog

### DIFF
--- a/4bit-transformers-bitsandbytes.md
+++ b/4bit-transformers-bitsandbytes.md
@@ -239,7 +239,8 @@ Try out the Guananco model cited on the paper on [the playground](https://huggin
 	src="https://gradio.s3-us-west-2.amazonaws.com/3.32.0/gradio.js"
 ></script>
 
-<gradio-app space="uwnlp/guanaco-playground-tgi"></gradio-app>
+<gradio-app theme_mode="light"
+ space="uwnlp/guanaco-playground-tgi"></gradio-app>
 
 ## Acknowledgements
 

--- a/4bit-transformers-bitsandbytes.md
+++ b/4bit-transformers-bitsandbytes.md
@@ -239,8 +239,7 @@ Try out the Guananco model cited on the paper on [the playground](https://huggin
 	src="https://gradio.s3-us-west-2.amazonaws.com/3.32.0/gradio.js"
 ></script>
 
-<gradio-app theme_mode="light"
- space="uwnlp/guanaco-playground-tgi"></gradio-app>
+<gradio-app theme_mode="light" space="uwnlp/guanaco-playground-tgi"></gradio-app>
 
 ## Acknowledgements
 

--- a/assisted-generation.md
+++ b/assisted-generation.md
@@ -175,8 +175,7 @@ Is the additional internal complexity worth it? Let’s have a look at the laten
 	src="https://gradio.s3-us-west-2.amazonaws.com/3.28.2/gradio.js"
 ></script>
 
-<gradio-app theme_mode="light"
- space="joaogante/assisted_generation_benchmarks"></gradio-app>
+<gradio-app theme_mode="light" space="joaogante/assisted_generation_benchmarks"></gradio-app>
 
 
 Glancing at the collected numbers, we see that assisted generation can deliver significant latency reductions in diverse settings, but it is not a silver bullet – you should benchmark it before applying it to your use case. We can conclude that assisted generation:
@@ -202,8 +201,7 @@ Why don't you see it for yourself, so get a feeling of assisted generation?
 
 
 <!-- [DEMO] -->
-<gradio-app theme_mode="light"
- space="joaogante/assisted_generation_demo"></gradio-app>
+<gradio-app theme_mode="light" space="joaogante/assisted_generation_demo"></gradio-app>
 
 
 ## Future directions

--- a/assisted-generation.md
+++ b/assisted-generation.md
@@ -175,7 +175,8 @@ Is the additional internal complexity worth it? Let’s have a look at the laten
 	src="https://gradio.s3-us-west-2.amazonaws.com/3.28.2/gradio.js"
 ></script>
 
-<gradio-app space="joaogante/assisted_generation_benchmarks"></gradio-app>
+<gradio-app theme_mode="light"
+ space="joaogante/assisted_generation_benchmarks"></gradio-app>
 
 
 Glancing at the collected numbers, we see that assisted generation can deliver significant latency reductions in diverse settings, but it is not a silver bullet – you should benchmark it before applying it to your use case. We can conclude that assisted generation:
@@ -201,7 +202,8 @@ Why don't you see it for yourself, so get a feeling of assisted generation?
 
 
 <!-- [DEMO] -->
-<gradio-app space="joaogante/assisted_generation_demo"></gradio-app>
+<gradio-app theme_mode="light"
+ space="joaogante/assisted_generation_demo"></gradio-app>
 
 
 ## Future directions

--- a/diffusion-models-event.md
+++ b/diffusion-models-event.md
@@ -15,7 +15,8 @@ We are excited to share that the [Diffusion Models Class](https://github.com/hug
 
 <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.6/gradio.js "></script>
 
-<gradio-app space="runwayml/stable-diffusion-v1-5"></gradio-app>
+<gradio-app theme_mode="light"
+ space="runwayml/stable-diffusion-v1-5"></gradio-app>
 
 To go with this release, we are organising a **live community event on November 30th** to which you are invited! The program includes exciting talks from the creators of Stable Diffusion, researchers at Stability AI and Meta, and more!
 

--- a/diffusion-models-event.md
+++ b/diffusion-models-event.md
@@ -15,8 +15,7 @@ We are excited to share that the [Diffusion Models Class](https://github.com/hug
 
 <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.6/gradio.js "></script>
 
-<gradio-app theme_mode="light"
- space="runwayml/stable-diffusion-v1-5"></gradio-app>
+<gradio-app theme_mode="light" space="runwayml/stable-diffusion-v1-5"></gradio-app>
 
 To go with this release, we are organising a **live community event on November 30th** to which you are invited! The program includes exciting talks from the creators of Stable Diffusion, researchers at Stability AI and Meta, and more!
 

--- a/falcon.md
+++ b/falcon.md
@@ -68,7 +68,8 @@ This trick doesn’t significantly influence pretraining, but it greatly [improv
 You can easily try the Big Falcon Model (40 billion parameters!) in [this Space](https://huggingface.co/spaces/HuggingFaceH4/falcon-chat) or in the playground embedded below:
 
 <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.32.0/gradio.js"> </script>
-<gradio-app space="HuggingFaceH4/falcon-chat-demo-for-blog"></gradio-app>
+<gradio-app theme_mode="light"
+ space="HuggingFaceH4/falcon-chat-demo-for-blog"></gradio-app>
 
 Under the hood, this playground uses Hugging Face's [Text Generation Inference](https://github.com/huggingface/text-generation-inference), a scalable Rust, Python, and gRPC server for fast & efficient text generation. It's the same technology that powers [HuggingChat](https://huggingface.co/chat/).
 

--- a/falcon.md
+++ b/falcon.md
@@ -68,8 +68,7 @@ This trick doesn’t significantly influence pretraining, but it greatly [improv
 You can easily try the Big Falcon Model (40 billion parameters!) in [this Space](https://huggingface.co/spaces/HuggingFaceH4/falcon-chat) or in the playground embedded below:
 
 <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.32.0/gradio.js"> </script>
-<gradio-app theme_mode="light"
- space="HuggingFaceH4/falcon-chat-demo-for-blog"></gradio-app>
+<gradio-app theme_mode="light" space="HuggingFaceH4/falcon-chat-demo-for-blog"></gradio-app>
 
 Under the hood, this playground uses Hugging Face's [Text Generation Inference](https://github.com/huggingface/text-generation-inference), a scalable Rust, Python, and gRPC server for fast & efficient text generation. It's the same technology that powers [HuggingChat](https://huggingface.co/chat/).
 

--- a/image-similarity.md
+++ b/image-similarity.md
@@ -268,7 +268,8 @@ Finally, you can try out the following Space that builds a mini image similarity
 
 <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.12.0/gradio.js"></script>
 
-<gradio-app space="sayakpaul/fetch-similar-images"></gradio-app>
+<gradio-app theme_mode="light"
+ space="sayakpaul/fetch-similar-images"></gradio-app>
 
 In this post, we ran through a quickstart for building image similarity systems. If you found this post interesting, we highly recommend building on top of the concepts we discussed here so you can get more comfortable with the inner workings.
 

--- a/image-similarity.md
+++ b/image-similarity.md
@@ -268,8 +268,7 @@ Finally, you can try out the following Space that builds a mini image similarity
 
 <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.12.0/gradio.js"></script>
 
-<gradio-app theme_mode="light"
- space="sayakpaul/fetch-similar-images"></gradio-app>
+<gradio-app theme_mode="light" space="sayakpaul/fetch-similar-images"></gradio-app>
 
 In this post, we ran through a quickstart for building image similarity systems. If you found this post interesting, we highly recommend building on top of the concepts we discussed here so you can get more comfortable with the inner workings.
 

--- a/instruction-tuning-sd.md
+++ b/instruction-tuning-sd.md
@@ -180,7 +180,8 @@ You can try out the interactive demo below to make Stable Diffusion follow speci
 
 <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.29.0/gradio.js"></script>
 
-<gradio-app src="https://instruction-tuning-sd-instruction-tuned-sd.hf.space"></gradio-app>
+<gradio-app theme_mode="light"
+ src="https://instruction-tuning-sd-instruction-tuned-sd.hf.space"></gradio-app>
 
 ## Potential applications and limitations
 

--- a/instruction-tuning-sd.md
+++ b/instruction-tuning-sd.md
@@ -180,8 +180,7 @@ You can try out the interactive demo below to make Stable Diffusion follow speci
 
 <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.29.0/gradio.js"></script>
 
-<gradio-app theme_mode="light"
- src="https://instruction-tuning-sd-instruction-tuned-sd.hf.space"></gradio-app>
+<gradio-app theme_mode="light" src="https://instruction-tuning-sd-instruction-tuned-sd.hf.space"></gradio-app>
 
 ## Potential applications and limitations
 

--- a/llama2.md
+++ b/llama2.md
@@ -72,8 +72,7 @@ If you’ve been waiting for an open alternative to closed-source chatbots, Llam
 You can easily try the Big Llama 2 Model (70 billion parameters!) in [this Space](https://huggingface.co/spaces/ysharma/Explore_llamav2_with_TGI) or in the playground embedded below:
 
 <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.37.0/gradio.js"> </script>
-<gradio-app theme_mode="light"
- space="ysharma/Explore_llamav2_with_TGI"></gradio-app>
+<gradio-app theme_mode="light" space="ysharma/Explore_llamav2_with_TGI"></gradio-app>
 
 Under the hood, this playground uses Hugging Face's [Text Generation Inference](https://github.com/huggingface/text-generation-inference), the same technology that powers [HuggingChat](https://huggingface.co/chat/), and which we'll share more in the following sections.
 

--- a/llama2.md
+++ b/llama2.md
@@ -72,7 +72,8 @@ If you’ve been waiting for an open alternative to closed-source chatbots, Llam
 You can easily try the Big Llama 2 Model (70 billion parameters!) in [this Space](https://huggingface.co/spaces/ysharma/Explore_llamav2_with_TGI) or in the playground embedded below:
 
 <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.37.0/gradio.js"> </script>
-<gradio-app space="ysharma/Explore_llamav2_with_TGI"></gradio-app>
+<gradio-app theme_mode="light"
+ space="ysharma/Explore_llamav2_with_TGI"></gradio-app>
 
 Under the hood, this playground uses Hugging Face's [Text Generation Inference](https://github.com/huggingface/text-generation-inference), the same technology that powers [HuggingChat](https://huggingface.co/chat/), and which we'll share more in the following sections.
 

--- a/spaces_3dmoljs.md
+++ b/spaces_3dmoljs.md
@@ -40,8 +40,7 @@ We will build a simple demo app that can accept either a 4-digit PDB code or a P
 
 <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.1.7/gradio.js"></script>
 
-<gradio-app theme_mode="light"
- space="simonduerr/3dmol.js"></gradio-app>
+<gradio-app theme_mode="light" space="simonduerr/3dmol.js"></gradio-app>
 
 ```python
 import gradio as gr
@@ -150,8 +149,7 @@ You can check the [source code](https://huggingface.co/spaces/simonduerr/3dmol.j
 
 For a production example, you can check the [ProteinMPNN](https://hf.space/simonduerr/ProteinMPNN) space where a user can upload a backbone, the inverse folding model ProteinMPNN predicts new optimal sequences and then one can run AlphaFold2 on all predicted sequences to verify whether they adopt the initial input backbone. Successful redesigns that qualitiatively adopt the same structure as predicted by AlphaFold2 with high pLDDT score should be tested in the lab. 
 
-<gradio-app theme_mode="light"
- space="simonduerr/ProteinMPNN"></gradio-app>
+<gradio-app theme_mode="light" space="simonduerr/ProteinMPNN"></gradio-app>
 
 # Issues
 

--- a/spaces_3dmoljs.md
+++ b/spaces_3dmoljs.md
@@ -40,7 +40,8 @@ We will build a simple demo app that can accept either a 4-digit PDB code or a P
 
 <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.1.7/gradio.js"></script>
 
-<gradio-app space="simonduerr/3dmol.js"></gradio-app>
+<gradio-app theme_mode="light"
+ space="simonduerr/3dmol.js"></gradio-app>
 
 ```python
 import gradio as gr
@@ -149,7 +150,8 @@ You can check the [source code](https://huggingface.co/spaces/simonduerr/3dmol.j
 
 For a production example, you can check the [ProteinMPNN](https://hf.space/simonduerr/ProteinMPNN) space where a user can upload a backbone, the inverse folding model ProteinMPNN predicts new optimal sequences and then one can run AlphaFold2 on all predicted sequences to verify whether they adopt the initial input backbone. Successful redesigns that qualitiatively adopt the same structure as predicted by AlphaFold2 with high pLDDT score should be tested in the lab. 
 
-<gradio-app space="simonduerr/ProteinMPNN"></gradio-app>
+<gradio-app theme_mode="light"
+ space="simonduerr/ProteinMPNN"></gradio-app>
 
 # Issues
 

--- a/stackllama.md
+++ b/stackllama.md
@@ -33,8 +33,7 @@ By combining these approaches, we are releasing the StackLLaMA model. This model
 	type="module"
 	src="https://gradio.s3-us-west-2.amazonaws.com/3.23.0/gradio.js"></script>
 
-<gradio-app theme_mode="light"
- src="https://trl-lib-stack-llama.hf.space"></gradio-app>
+<gradio-app theme_mode="light" src="https://trl-lib-stack-llama.hf.space"></gradio-app>
 
 ## The LLaMA model
 

--- a/stackllama.md
+++ b/stackllama.md
@@ -33,7 +33,8 @@ By combining these approaches, we are releasing the StackLLaMA model. This model
 	type="module"
 	src="https://gradio.s3-us-west-2.amazonaws.com/3.23.0/gradio.js"></script>
 
-<gradio-app src="https://trl-lib-stack-llama.hf.space"></gradio-app>
+<gradio-app theme_mode="light"
+ src="https://trl-lib-stack-llama.hf.space"></gradio-app>
 
 ## The LLaMA model
 

--- a/starchat-alpha.md
+++ b/starchat-alpha.md
@@ -37,8 +37,7 @@ As a teaser of the end result, try asking StarChat a few programming questions i
 	src="https://gradio.s3-us-west-2.amazonaws.com/3.28.2/gradio.js"
 ></script>
 
-<gradio-app theme_mode="light"
- src="https://huggingfaceh4-starchat-playground.hf.space"></gradio-app>
+<gradio-app theme_mode="light" src="https://huggingfaceh4-starchat-playground.hf.space"></gradio-app>
 
 
 You can also find the code, dataset, and model used to produce the demo at the following links:

--- a/starchat-alpha.md
+++ b/starchat-alpha.md
@@ -37,7 +37,8 @@ As a teaser of the end result, try asking StarChat a few programming questions i
 	src="https://gradio.s3-us-west-2.amazonaws.com/3.28.2/gradio.js"
 ></script>
 
-<gradio-app src="https://huggingfaceh4-starchat-playground.hf.space"></gradio-app>
+<gradio-app theme_mode="light"
+ src="https://huggingfaceh4-starchat-playground.hf.space"></gradio-app>
 
 
 You can also find the code, dataset, and model used to produce the demo at the following links:

--- a/text-to-video.md
+++ b/text-to-video.md
@@ -76,11 +76,13 @@ At Hugging Face, our goal is to make it easier to use and build upon state-of-th
 
 <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.23.0/gradio.js"></script>
 
-<gradio-app space="PAIR/Text2Video-Zero"></gradio-app>
+<gradio-app theme_mode="light"
+ space="PAIR/Text2Video-Zero"></gradio-app>
 
 Apart from using demos to experiment with pretrained text-to-video models, you can also use the [Tune-a-Video training demo](https://huggingface.co/spaces/Tune-A-Video-library/Tune-A-Video-Training-UI) to fine-tune an existing text-to-image model with your own text-video pair. To try it out, upload a video and enter a text prompt that describes the video. Once the training is done, you can upload it to the Hub under the Tune-a-Video community or your own username, publicly or privately. Once the training is done, simply head over to the *Run* tab of the demo to generate videos from any text prompt. 
 
-<gradio-app space="Tune-A-Video-library/Tune-A-Video-Training-UI"></gradio-app>
+<gradio-app theme_mode="light"
+ space="Tune-A-Video-library/Tune-A-Video-Training-UI"></gradio-app>
 
 
 All Spaces on the 🤗 Hub are Git repos you can clone and run on your local or deployment environment. Let’s clone the ModelScope demo, install the requirements, and run it locally.

--- a/text-to-video.md
+++ b/text-to-video.md
@@ -76,13 +76,11 @@ At Hugging Face, our goal is to make it easier to use and build upon state-of-th
 
 <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.23.0/gradio.js"></script>
 
-<gradio-app theme_mode="light"
- space="PAIR/Text2Video-Zero"></gradio-app>
+<gradio-app theme_mode="light" space="PAIR/Text2Video-Zero"></gradio-app>
 
 Apart from using demos to experiment with pretrained text-to-video models, you can also use the [Tune-a-Video training demo](https://huggingface.co/spaces/Tune-A-Video-library/Tune-A-Video-Training-UI) to fine-tune an existing text-to-image model with your own text-video pair. To try it out, upload a video and enter a text prompt that describes the video. Once the training is done, you can upload it to the Hub under the Tune-a-Video community or your own username, publicly or privately. Once the training is done, simply head over to the *Run* tab of the demo to generate videos from any text prompt. 
 
-<gradio-app theme_mode="light"
- space="Tune-A-Video-library/Tune-A-Video-Training-UI"></gradio-app>
+<gradio-app theme_mode="light" space="Tune-A-Video-library/Tune-A-Video-Training-UI"></gradio-app>
 
 
 All Spaces on the 🤗 Hub are Git repos you can clone and run on your local or deployment environment. Let’s clone the ModelScope demo, install the requirements, and run it locally.

--- a/zh/assisted-generation.md
+++ b/zh/assisted-generation.md
@@ -172,7 +172,8 @@ print(tokenizer.batch_decode(outputs, skip_special_tokens=True))
 	src="https://gradio.s3-us-west-2.amazonaws.com/3.28.2/gradio.js"
 ></script>
 
-<gradio-app space="joaogante/assisted_generation_benchmarks"></gradio-app>
+<gradio-app theme_mode="light"
+ space="joaogante/assisted_generation_benchmarks"></gradio-app>
 
 通过观察收集到的数据，我们发现辅助生成可以在不同的设置中显著减少延迟，但这不是灵丹妙药——你应该在应用之前对其进行系统的评估以清晰使用该方法的代价。对于辅助生成方法，我们可以得出结论:
 
@@ -195,7 +196,8 @@ print(tokenizer.batch_decode(outputs, skip_special_tokens=True))
 不妨亲眼看一看，感受一下辅助生成的魅力？
 
 <!-- [DEMO] -->
-<gradio-app space="joaogante/assisted_generation_demo"></gradio-app>
+<gradio-app theme_mode="light"
+ space="joaogante/assisted_generation_demo"></gradio-app>
 
 ## 未来发展方向
 

--- a/zh/assisted-generation.md
+++ b/zh/assisted-generation.md
@@ -172,8 +172,7 @@ print(tokenizer.batch_decode(outputs, skip_special_tokens=True))
 	src="https://gradio.s3-us-west-2.amazonaws.com/3.28.2/gradio.js"
 ></script>
 
-<gradio-app theme_mode="light"
- space="joaogante/assisted_generation_benchmarks"></gradio-app>
+<gradio-app theme_mode="light" space="joaogante/assisted_generation_benchmarks"></gradio-app>
 
 通过观察收集到的数据，我们发现辅助生成可以在不同的设置中显著减少延迟，但这不是灵丹妙药——你应该在应用之前对其进行系统的评估以清晰使用该方法的代价。对于辅助生成方法，我们可以得出结论:
 
@@ -196,8 +195,7 @@ print(tokenizer.batch_decode(outputs, skip_special_tokens=True))
 不妨亲眼看一看，感受一下辅助生成的魅力？
 
 <!-- [DEMO] -->
-<gradio-app theme_mode="light"
- space="joaogante/assisted_generation_demo"></gradio-app>
+<gradio-app theme_mode="light" space="joaogante/assisted_generation_demo"></gradio-app>
 
 ## 未来发展方向
 

--- a/zh/falcon.md
+++ b/zh/falcon.md
@@ -69,8 +69,7 @@ Falcon 模型的另一个有趣的特性是其使用了 [**多查询注意力 (m
 通过 [这个 Space](https://huggingface.co/spaces/HuggingFaceH4/falcon-chat) 或下面的应用，你可以很轻松地试用一下大的 Falcon 模型 (400 亿参数！):
 
 <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.32.0/gradio.js"> </script>
-<gradio-app theme_mode="light"
- space="HuggingFaceH4/falcon-chat-demo-for-blog"></gradio-app>
+<gradio-app theme_mode="light" space="HuggingFaceH4/falcon-chat-demo-for-blog"></gradio-app>
 
 上面的应用使用了 Hugging Face 的 [Text Generation Inference](https://github.com/huggingface/text-generation-inference) 技术，它是一个可扩展的、快速高效的文本生成服务，使用了 Rust、Python 以及 gRPC 等技术。[HuggingChat](https://huggingface.co/chat/) 也使用了相同的技术。
 

--- a/zh/falcon.md
+++ b/zh/falcon.md
@@ -69,7 +69,8 @@ Falcon 模型的另一个有趣的特性是其使用了 [**多查询注意力 (m
 通过 [这个 Space](https://huggingface.co/spaces/HuggingFaceH4/falcon-chat) 或下面的应用，你可以很轻松地试用一下大的 Falcon 模型 (400 亿参数！):
 
 <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.32.0/gradio.js"> </script>
-<gradio-app space="HuggingFaceH4/falcon-chat-demo-for-blog"></gradio-app>
+<gradio-app theme_mode="light"
+ space="HuggingFaceH4/falcon-chat-demo-for-blog"></gradio-app>
 
 上面的应用使用了 Hugging Face 的 [Text Generation Inference](https://github.com/huggingface/text-generation-inference) 技术，它是一个可扩展的、快速高效的文本生成服务，使用了 Rust、Python 以及 gRPC 等技术。[HuggingChat](https://huggingface.co/chat/) 也使用了相同的技术。
 

--- a/zh/image-similarity.md
+++ b/zh/image-similarity.md
@@ -271,8 +271,7 @@ scores, retrieved_examples = dataset_with_embeddings.get_nearest_examples(
 
 <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.12.0/gradio.js"></script>
 
-<gradio-app theme_mode="light"
- space="sayakpaul/fetch-similar-images"></gradio-app>
+<gradio-app theme_mode="light" space="sayakpaul/fetch-similar-images"></gradio-app>
 
 在本文中，我们快速入门并构建了一个图像相似度系统。如果你觉得这篇文章很有趣，我们强烈建议你基于我们讨论的概念继续构建你的系统，这样你就可以更加熟悉内部工作原理。
 

--- a/zh/image-similarity.md
+++ b/zh/image-similarity.md
@@ -271,7 +271,8 @@ scores, retrieved_examples = dataset_with_embeddings.get_nearest_examples(
 
 <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.12.0/gradio.js"></script>
 
-<gradio-app space="sayakpaul/fetch-similar-images"></gradio-app>
+<gradio-app theme_mode="light"
+ space="sayakpaul/fetch-similar-images"></gradio-app>
 
 在本文中，我们快速入门并构建了一个图像相似度系统。如果你觉得这篇文章很有趣，我们强烈建议你基于我们讨论的概念继续构建你的系统，这样你就可以更加熟悉内部工作原理。
 

--- a/zh/instruction-tuning-sd.md
+++ b/zh/instruction-tuning-sd.md
@@ -184,7 +184,8 @@ translators:
 
 <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.29.0/gradio.js"></script>
 
-<gradio-app src="https://instruction-tuning-sd-instruction-tuned-sd.hf.space"></gradio-app>
+<gradio-app theme_mode="light"
+ src="https://instruction-tuning-sd-instruction-tuned-sd.hf.space"></gradio-app>
 
 ## 潜在的应用及其限制
 

--- a/zh/instruction-tuning-sd.md
+++ b/zh/instruction-tuning-sd.md
@@ -184,8 +184,7 @@ translators:
 
 <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.29.0/gradio.js"></script>
 
-<gradio-app theme_mode="light"
- src="https://instruction-tuning-sd-instruction-tuned-sd.hf.space"></gradio-app>
+<gradio-app theme_mode="light" src="https://instruction-tuning-sd-instruction-tuned-sd.hf.space"></gradio-app>
 
 ## 潜在的应用及其限制
 

--- a/zh/starchat-alpha.md
+++ b/zh/starchat-alpha.md
@@ -41,8 +41,7 @@ translators:
 	src="https://gradio.s3-us-west-2.amazonaws.com/3.28.2/gradio.js"
 ></script>
 
-<gradio-app theme_mode="light"
- src="https://huggingfaceh4-starchat-playground.hf.space"></gradio-app>
+<gradio-app theme_mode="light" src="https://huggingfaceh4-starchat-playground.hf.space"></gradio-app>
 
 你也可以查看生成上面演示所使用的代码、数据集和模型:
 

--- a/zh/starchat-alpha.md
+++ b/zh/starchat-alpha.md
@@ -41,7 +41,8 @@ translators:
 	src="https://gradio.s3-us-west-2.amazonaws.com/3.28.2/gradio.js"
 ></script>
 
-<gradio-app src="https://huggingfaceh4-starchat-playground.hf.space"></gradio-app>
+<gradio-app theme_mode="light"
+ src="https://huggingfaceh4-starchat-playground.hf.space"></gradio-app>
 
 你也可以查看生成上面演示所使用的代码、数据集和模型:
 

--- a/zh/text-to-video.md
+++ b/zh/text-to-video.md
@@ -85,13 +85,11 @@ Text2Video-Zero 是一个文本引导的视频生成和处理框架，其工作�
 在 Hugging Face，我们的目标是使 Hugging Face 库更易于使用并包含最先进的研究。你可以前往 Hub 查看和体验由 🤗 团队、无数社区贡献者和研究者贡献的 Spaces 演示。目前，上面有 [VideoGPT](https://huggingface.co/spaces/akhaliq/VideoGPT)、[CogVideo](https://huggingface.co/spaces/THUDM/CogVideo)、[ModelScope 文生视频](https://huggingface.co/spaces/damo-vilab/modelscope-text-to-video-synthesis) 以及 [Text2Video-Zero](https://huggingface.co/spaces/PAIR/Text2Video-Zero) 的应用演示，后面还会越来越多，敬请期待。要了解这些模型能用来做什么，我们可以看一下 Text2Video-Zero 的应用演示。该演示不仅展示了文生视频应用，而且还包含多种其他生成模式，如文本引导的视频编辑，以及基于姿势、深度、边缘输入结合文本提示进行联合条件下的视频生成。
 
 <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.1.7/gradio.js"></script>
-<gradio-app theme_mode="light"
- space="PAIR/Text2Video-Zero"></gradio-app>
+<gradio-app theme_mode="light" space="PAIR/Text2Video-Zero"></gradio-app>
 
 除了使用应用演示来尝试预训练文生视频模型外，你还可以使用 [Tune-a-Video 训练演示](https://huggingface.co/spaces/Tune-A-Video-library/Tune-A-Video-Training-UI) 使用你自己的 `文本 - 视频对`微调现有的文生图模型。仅需上传视频并输入描述该视频的文本提示即就可以了。你可以将训得的模型上传到公开的 Tune-a-Video 社区的 Hub 或你私人用户名下的 Hub。训练完成后，只需转到演示的 _Run_ 选项卡即可根据任何文本提示生成视频。
 
-<gradio-app theme_mode="light"
- space="Tune-A-Video-library/Tune-A-Video-Training-UI"></gradio-app>
+<gradio-app theme_mode="light" space="Tune-A-Video-library/Tune-A-Video-Training-UI"></gradio-app>
 
 🤗 Hub 上的所有 Space 其实都是 Git 存储库，你可以在本地或部署环境中克隆和运行它们。下面克隆一下 ModelScope 演示，安装环境，并在本地运行它。
 

--- a/zh/text-to-video.md
+++ b/zh/text-to-video.md
@@ -85,11 +85,13 @@ Text2Video-Zero 是一个文本引导的视频生成和处理框架，其工作�
 在 Hugging Face，我们的目标是使 Hugging Face 库更易于使用并包含最先进的研究。你可以前往 Hub 查看和体验由 🤗 团队、无数社区贡献者和研究者贡献的 Spaces 演示。目前，上面有 [VideoGPT](https://huggingface.co/spaces/akhaliq/VideoGPT)、[CogVideo](https://huggingface.co/spaces/THUDM/CogVideo)、[ModelScope 文生视频](https://huggingface.co/spaces/damo-vilab/modelscope-text-to-video-synthesis) 以及 [Text2Video-Zero](https://huggingface.co/spaces/PAIR/Text2Video-Zero) 的应用演示，后面还会越来越多，敬请期待。要了解这些模型能用来做什么，我们可以看一下 Text2Video-Zero 的应用演示。该演示不仅展示了文生视频应用，而且还包含多种其他生成模式，如文本引导的视频编辑，以及基于姿势、深度、边缘输入结合文本提示进行联合条件下的视频生成。
 
 <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.1.7/gradio.js"></script>
-<gradio-app space="PAIR/Text2Video-Zero"></gradio-app>
+<gradio-app theme_mode="light"
+ space="PAIR/Text2Video-Zero"></gradio-app>
 
 除了使用应用演示来尝试预训练文生视频模型外，你还可以使用 [Tune-a-Video 训练演示](https://huggingface.co/spaces/Tune-A-Video-library/Tune-A-Video-Training-UI) 使用你自己的 `文本 - 视频对`微调现有的文生图模型。仅需上传视频并输入描述该视频的文本提示即就可以了。你可以将训得的模型上传到公开的 Tune-a-Video 社区的 Hub 或你私人用户名下的 Hub。训练完成后，只需转到演示的 _Run_ 选项卡即可根据任何文本提示生成视频。
 
-<gradio-app space="Tune-A-Video-library/Tune-A-Video-Training-UI"></gradio-app>
+<gradio-app theme_mode="light"
+ space="Tune-A-Video-library/Tune-A-Video-Training-UI"></gradio-app>
 
 🤗 Hub 上的所有 Space 其实都是 Git 存储库，你可以在本地或部署环境中克隆和运行它们。下面克隆一下 ModelScope 演示，安装环境，并在本地运行它。
 


### PR DESCRIPTION
Gradio uses the system theme, but the blog only renders in light mode, so it can be jarring to have a dark mode gradio app in a light mode page. Fix embedded gradio apps to light mode.