### PR TITLE
Add correct hardware requirements number for falcon 180B

### DIFF
--- a/falcon-180b.md
+++ b/falcon-180b.md
@@ -86,8 +86,8 @@ You can easily try the Big Falcon Model (180 billion parameters!) in [this Space
 | Falcon 180B | Training  | Full fine-tuning | 5120GB              | 8x 8x A100 80GB |
 | Falcon 180B | Training  | LoRA with ZeRO-3 | 1280GB              | 2x 8x A100 80GB |
 | Falcon 180B | Training  | QLoRA            | 160GB               | 2x A100 80GB    |
-| Falcon 180B | Inference | BF16/FP16        | 640GB               | 8x A100 80GB    |
-| Falcon 180B | Inference | GPTQ/int4        | 320GB               | 8x A100 40GB    |
+| Falcon 180B | Inference | BF16/FP16        | 320GB               | 4x A100 80GB    |
+| Falcon 180B | Inference | GPTQ/int4        | 90GB               | 2x A100 40GB    |
 
 ### Prompt format
 

--- a/falcon-180b.md
+++ b/falcon-180b.md
@@ -86,7 +86,7 @@ You can easily try the Big Falcon Model (180 billion parameters!) in [this Space
 | Falcon 180B | Training  | Full fine-tuning | 5120GB              | 8x 8x A100 80GB |
 | Falcon 180B | Training  | LoRA with ZeRO-3 | 1280GB              | 2x 8x A100 80GB |
 | Falcon 180B | Training  | QLoRA            | 160GB               | 2x A100 80GB    |
-| Falcon 180B | Inference | BF16/FP16        | 320GB               | 4x A100 80GB    |
+| Falcon 180B | Inference | BF16/FP16        | 360GB               | 5x A100 80GB    |
 | Falcon 180B | Inference | GPTQ/int4        | 90GB               | 2x A100 40GB    |
 
 ### Prompt format


### PR DESCRIPTION
I am not sure the numbers for hardware requirements are correct as for half precision models you need 2x the number of parameters thus 340GB in the case of falcon 180B, with respect to GPTQ it should be around 90GB I believe (180 / 2 + 5-10% overhead for the quantization statistics - maybe I am wrong here but it is not 320GB for sure) 

Spotted in: https://twitter.com/Yampeleg/status/1699417031185981673?s=20

cc @pacman100 @philschmid @osanseviero 