### PR TITLE
Removing S3 link follow hacker one report.

### DIFF
--- a/few-shot-learning-gpt-neo-and-inference-api.md
+++ b/few-shot-learning-gpt-neo-and-inference-api.md
@@ -12,9 +12,6 @@ authors:
 
 In many Machine Learning applications, the amount of available labeled data is a barrier to producing a high-performing model. The latest developments in NLP show that you can overcome this limitation by providing a few examples at inference time with a large language model - a technique known as Few-Shot Learning. In this blog post, we'll explain what Few-Shot Learning is, and explore how a large language model called GPT-Neo, and the 🤗 Accelerated Inference API, can be used to generate your own predictions.
 
-<script defer src="https://gpt-neo-accelerated-inference-api.s3-eu-west-1.amazonaws.com/fewShotInference.js"></script>
-<few-shot-inference-widget ></few-shot-inference-widget>
-
 
 ## What is Few-Shot Learning?
 


### PR DESCRIPTION
I am making this update because the link to the script is no longer available, and a bug hunter from HackerOne purchased it to demonstrate the possibility of injecting malicious JavaScript onto this blog page.

Following a discussion on Slack, the decision to remove the link has been made.