### PR TITLE
Replace feature extractor by image processor

### DIFF
--- a/fine-tune-vit.md
+++ b/fine-tune-vit.md
@@ -171,29 +171,28 @@ From what I'm seeing,
 - Bean Rust:  Has circular brown spots surrounded with a white-ish yellow ring
 - Healthy: ...looks healthy. 🤷‍♂️
 
-## Loading ViT Feature Extractor
+## Loading ViT Image Processor
 
 Now we know what our images look like and better understand the problem we're trying to solve. Let's see how we can prepare these images for our model!
 
 When ViT models are trained, specific transformations are applied to images fed into them. Use the wrong transformations on your image, and the model won't understand what it's seeing! 🖼 ➡️ 🔢
 
-To make sure we apply the correct transformations, we will use a [`ViTFeatureExtractor`](https://huggingface.co/docs/transformers/model_doc/vit#transformers.ViTFeatureExtractor) initialized with a configuration that was saved along with the pretrained model we plan to use. In our case, we'll be using the [google/vit-base-patch16-224-in21k](https://huggingface.co/google/vit-base-patch16-224-in21k) model, so let's load its feature extractor from the Hugging Face Hub.
+To make sure we apply the correct transformations, we will use a [`ViTImageProcessor`](https://huggingface.co/docs/transformers/model_doc/vit#transformers.ViTImageProcessor) initialized with a configuration that was saved along with the pretrained model we plan to use. In our case, we'll be using the [google/vit-base-patch16-224-in21k](https://huggingface.co/google/vit-base-patch16-224-in21k) model, so let's load its image processor from the Hugging Face Hub.
 
 
 ```python
-from transformers import ViTFeatureExtractor
+from transformers import ViTImageProcessor
 
 model_name_or_path = 'google/vit-base-patch16-224-in21k'
-feature_extractor = ViTFeatureExtractor.from_pretrained(model_name_or_path)
+processor = ViTImageProcessor.from_pretrained(model_name_or_path)
 ```
 
-You can see the feature extractor configuration by printing it.
+You can see the image processor configuration by printing it.
 
 
-    ViTFeatureExtractor {
+    ViTImageProcessor {
       "do_normalize": true,
       "do_resize": true,
-      "feature_extractor_type": "ViTFeatureExtractor",
       "image_mean": [
         0.5,
         0.5,
@@ -210,14 +209,14 @@ You can see the feature extractor configuration by printing it.
 
 
 
-To process an image, simply pass it to the feature extractor's call function. This will return a dict containing `pixel values`, which is the numeric representation to be passed to the model.
+To process an image, simply pass it to the image processor's call function. This will return a dict containing `pixel values`, which is the numeric representation to be passed to the model.
 
 You get a NumPy array by default, but if you add the `return_tensors='pt'` argument, you'll get back `torch` tensors instead.
 
 
 
 ```python
-feature_extractor(image, return_tensors='pt')
+processor(image, return_tensors='pt')
 ```
 
 Should give you something like...
@@ -235,7 +234,7 @@ Now that you know how to read images and transform them into inputs, let's write
 
 ```python
 def process_example(example):
-    inputs = feature_extractor(example['image'], return_tensors='pt')
+    inputs = processor(example['image'], return_tensors='pt')
     inputs['labels'] = example['labels']
     return inputs
 ```
@@ -263,7 +262,7 @@ ds = load_dataset('beans')
 
 def transform(example_batch):
     # Take a list of PIL images and turn them to pixel values
-    inputs = feature_extractor([x for x in example_batch['image']], return_tensors='pt')
+    inputs = processor([x for x in example_batch['image']], return_tensors='pt')
 
     # Don't forget to include the labels!
     inputs['labels'] = example_batch['labels']
@@ -399,7 +398,7 @@ trainer = Trainer(
     compute_metrics=compute_metrics,
     train_dataset=prepared_ds["train"],
     eval_dataset=prepared_ds["validation"],
-    tokenizer=feature_extractor,
+    tokenizer=processor,
 )
 ```
 

--- a/image-similarity.md
+++ b/image-similarity.md
@@ -45,11 +45,11 @@ To compute the embeddings from the images, we'll use a vision model that has som
 For loading the model, we leverage the [`AutoModel` class](https://huggingface.co/docs/transformers/model_doc/auto#transformers.AutoModel). It provides an interface for us to load any compatible model checkpoint from the Hugging Face Hub. Alongside the model, we also load the processor associated with the model for data preprocessing. 
 
 ```py
-from transformers import AutoFeatureExtractor, AutoModel
+from transformers import AutoImageProcessor, AutoModel
 
 
 model_ckpt = "nateraw/vit-base-beans"
-extractor = AutoFeatureExtractor.from_pretrained(model_ckpt)
+extractor = AutoImageProcessor.from_pretrained(model_ckpt)
 model = AutoModel.from_pretrained(model_ckpt)
 ```
 

--- a/image-similarity.md
+++ b/image-similarity.md
@@ -49,7 +49,7 @@ from transformers import AutoImageProcessor, AutoModel
 
 
 model_ckpt = "nateraw/vit-base-beans"
-extractor = AutoImageProcessor.from_pretrained(model_ckpt)
+processor = AutoImageProcessor.from_pretrained(model_ckpt)
 model = AutoModel.from_pretrained(model_ckpt)
 ```
 

--- a/notebooks/111_tf_serving_vision.ipynb
+++ b/notebooks/111_tf_serving_vision.ipynb
@@ -67,7 +67,7 @@
       },
       "outputs": [],
       "source": [
-        "from transformers import ViTFeatureExtractor, TFViTForImageClassification\n",
+        "from transformers import ViTImageProcessor, TFViTForImageClassification\n",
         "import tensorflow as tf\n",
         "import tempfile\n",
         "import requests\n",
@@ -288,8 +288,8 @@
         }
       ],
       "source": [
-        "feature_extractor = ViTFeatureExtractor()\n",
-        "feature_extractor"
+        "processor = ViTImageProcessor()\n",
+        "processor"
       ]
     },
     {
@@ -301,7 +301,7 @@
       "outputs": [],
       "source": [
         "CONCRETE_INPUT = \"pixel_values\"\n",
-        "SIZE = feature_extractor.size\n",
+        "SIZE = processor.size[\"height\"]\n",
         "INPUT_SHAPE = (SIZE, SIZE, 3)"
       ]
     },
@@ -314,7 +314,7 @@
       "outputs": [],
       "source": [
         "def normalize_img(\n",
-        "    img, mean=feature_extractor.image_mean, std=feature_extractor.image_std\n",
+        "    img, mean=processor.image_mean, std=processor.image_std\n",
         "):\n",
         "    # Scale to the value range of [0, 1] first and then normalize.\n",
         "    img = img / 255\n",

--- a/notebooks/112_vertex_ai_vision.ipynb
+++ b/notebooks/112_vertex_ai_vision.ipynb
@@ -132,7 +132,7 @@
         }
       ],
       "source": [
-        "from transformers import ViTFeatureExtractor, TFViTForImageClassification\n",
+        "from transformers import ViTImageProcessor, TFViTForImageClassification\n",
         "import tensorflow as tf\n",
         "import tempfile\n",
         "import requests\n",
@@ -442,8 +442,8 @@
         }
       ],
       "source": [
-        "feature_extractor = ViTFeatureExtractor()\n",
-        "feature_extractor"
+        "processor = ViTImageProcessor()\n",
+        "processor"
       ]
     },
     {
@@ -456,7 +456,7 @@
       "outputs": [],
       "source": [
         "CONCRETE_INPUT = \"pixel_values\"\n",
-        "SIZE = feature_extractor.size\n",
+        "SIZE = processor.size[\"height\"]\n",
         "INPUT_SHAPE = (SIZE, SIZE, 3)"
       ]
     },
@@ -469,7 +469,7 @@
       },
       "outputs": [],
       "source": [
-        "def normalize_img(img, mean=feature_extractor.image_mean, std=feature_extractor.image_std):\n",
+        "def normalize_img(img, mean=processor.image_mean, std=processor.image_std):\n",
         "    # Scale to the value range of [0, 1] first and then normalize.\n",
         "    img = img / 255\n",
         "    mean = tf.constant(mean)\n",

--- a/notebooks/56_fine_tune_segformer.ipynb
+++ b/notebooks/56_fine_tune_segformer.ipynb
@@ -1201,7 +1201,7 @@
         "id": "EobXJvy2EAQy"
       },
       "source": [
-        "## Feature extractor & data augmentation"
+        "## Image processor & data augmentation"
       ]
     },
     {
@@ -1210,7 +1210,7 @@
         "id": "Za3n6MH1UuDb"
       },
       "source": [
-        "A SegFormer model expects the input to be of a certain shape. To transform our training data to match the expected shape, we can use `SegFormerFeatureExtractor`. We could use the `ds.map` function to apply the feature extractor to the whole training dataset in advance, but this can take up a lot of disk space. Instead, we'll use a *transform*, which will only prepare a batch of data when that data is actually used (on-the-fly). This way, we can start training without waiting for further data preprocessing.\n",
+        "A SegFormer model expects the input to be of a certain shape. To transform our training data to match the expected shape, we can use `SegFormerImageProcessor`. We could use the `ds.map` function to apply the image processor to the whole training dataset in advance, but this can take up a lot of disk space. Instead, we'll use a *transform*, which will only prepare a batch of data when that data is actually used (on-the-fly). This way, we can start training without waiting for further data preprocessing.\n",
         "\n",
         "In our transform, we'll also define some data augmentations to make our model more resilient to different lighting conditions. We'll use the [`ColorJitter`](https://pytorch.org/vision/main/generated/torchvision.transforms.ColorJitter.html) function from `torchvision` to randomly change the brightness, contrast, saturation, and hue of the images in the batch."
       ]
@@ -1243,23 +1243,23 @@
       "source": [
         "from torchvision.transforms import ColorJitter\n",
         "from transformers import (\n",
-        "    SegformerFeatureExtractor,\n",
+        "    SegformerImageProcessor,\n",
         ")\n",
         "\n",
-        "feature_extractor = SegformerFeatureExtractor()\n",
+        "processor = SegformerImageProcessor()\n",
         "jitter = ColorJitter(brightness=0.25, contrast=0.25, saturation=0.25, hue=0.1) \n",
         "\n",
         "def train_transforms(example_batch):\n",
         "    images = [jitter(x) for x in example_batch['pixel_values']]\n",
         "    labels = [x for x in example_batch['label']]\n",
-        "    inputs = feature_extractor(images, labels)\n",
+        "    inputs = processor(images, labels)\n",
         "    return inputs\n",
         "\n",
         "\n",
         "def val_transforms(example_batch):\n",
         "    images = [x for x in example_batch['pixel_values']]\n",
         "    labels = [x for x in example_batch['label']]\n",
-        "    inputs = feature_extractor(images, labels)\n",
+        "    inputs = processor(images, labels)\n",
         "    return inputs\n",
         "\n",
         "\n",
@@ -1488,7 +1488,7 @@
         "            references=labels,\n",
         "            num_labels=len(id2label),\n",
         "            ignore_index=0,\n",
-        "            reduce_labels=feature_extractor.do_reduce_labels,\n",
+        "            reduce_labels=processor.do_reduce_labels,\n",
         "        )\n",
         "    \n",
         "    # add per category metrics as individual key-value pairs\n",
@@ -1565,7 +1565,7 @@
         "id": "YlOal7giORmw"
       },
       "source": [
-        "When we're done with training, we can push our fine-tuned model and the feature extractor to the Hugging Face hub.\n",
+        "When we're done with training, we can push our fine-tuned model and the image processor to the Hugging Face hub.\n",
         "\n",
         "This will also automatically create a model card with our results. We'll supply some extra information in `kwargs` to make the model card more complete."
       ]
@@ -1584,7 +1584,7 @@
         "    \"dataset\": hf_dataset_identifier,\n",
         "}\n",
         "\n",
-        "feature_extractor.push_to_hub(hub_model_id)\n",
+        "processor.push_to_hub(hub_model_id)\n",
         "trainer.push_to_hub(**kwargs)"
       ]
     },
@@ -1645,9 +1645,9 @@
       },
       "outputs": [],
       "source": [
-        "from transformers import SegformerFeatureExtractor, SegformerForSemanticSegmentation\n",
+        "from transformers import SegformerImageProcessor, SegformerForSemanticSegmentation\n",
         "\n",
-        "feature_extractor = SegformerFeatureExtractor.from_pretrained(\"nvidia/segformer-b0-finetuned-ade-512-512\")\n",
+        "processor = SegformerImageProcessor.from_pretrained(\"nvidia/segformer-b0-finetuned-ade-512-512\")\n",
         "model = SegformerForSemanticSegmentation.from_pretrained(f\"{hf_username}/{hub_model_id}\")"
       ]
     },
@@ -1679,7 +1679,7 @@
         "id": "7m7IfMv6R3_5"
       },
       "source": [
-        "To segment this test image, we first need to prepare the image using the feature extractor. Then we forward it through the model.\n",
+        "To segment this test image, we first need to prepare the image using the image processor. Then we forward it through the model.\n",
         "\n",
         "We also need to remember to upscale the output logits to the original image size. In order to get the actual category predictions, we just have to apply an `argmax` on the logits."
       ]
@@ -1694,7 +1694,7 @@
       "source": [
         "from torch import nn\n",
         "\n",
-        "inputs = feature_extractor(images=image, return_tensors=\"pt\")\n",
+        "inputs = processor(images=image, return_tensors=\"pt\")\n",
         "outputs = model(**inputs)\n",
         "logits = outputs.logits  # shape (batch_size, num_labels, height/4, width/4)\n",
         "\n",

--- a/openvino.md
+++ b/openvino.md
@@ -37,14 +37,14 @@ pip install pip --upgrade
 pip install optimum[openvino,nncf] torchvision evaluate
 ```
 
-Next, moving to a Python environment, we import the appropriate modules and download the original model as well as its feature extractor.
+Next, moving to a Python environment, we import the appropriate modules and download the original model as well as its processor.
 ​
 ```python
-from transformers import AutoFeatureExtractor, AutoModelForImageClassification
+from transformers import AutoImageProcessor, AutoModelForImageClassification
 ​
 model_id = "juliensimon/autotrain-food101-1471154050"
 model = AutoModelForImageClassification.from_pretrained(model_id)
-feature_extractor = AutoFeatureExtractor.from_pretrained(model_id)
+processor = AutoImageProcessor.from_pretrained(model_id)
 ```
 ​
 Post-training static quantization requires a calibration step where data is fed through the network in order to compute the quantized activation parameters. Here, we take 300 samples from the original dataset to build the calibration dataset.
@@ -60,7 +60,7 @@ calibration_dataset = quantizer.get_calibration_dataset(
 )
 ```
 
-As usual with image datasets, we need to apply the same image transformations that were used at training time. We use the preprocessing defined in the feature extractor. We also define a data collation function to feed the model batches of properly formatted tensors.
+As usual with image datasets, we need to apply the same image transformations that were used at training time. We use the preprocessing defined in the processor. We also define a data collation function to feed the model batches of properly formatted tensors.
 ​
 
 ```python
@@ -73,11 +73,12 @@ from torchvision.transforms import (
     ToTensor,
 )
 ​
-normalize = Normalize(mean=feature_extractor.image_mean, std=feature_extractor.image_std)
+normalize = Normalize(mean=processor.image_mean, std=processor.image_std)
+size = processor.size["height"]
 _val_transforms = Compose(
     [
-        Resize(feature_extractor.size),
-        CenterCrop(feature_extractor.size),
+        Resize(size),
+        CenterCrop(size),
         ToTensor(),
         normalize,
     ]
@@ -117,7 +118,7 @@ quantizer.quantize(
     remove_unused_columns=False,
     save_directory=save_dir,
 )
-feature_extractor.save_pretrained(save_dir)
+processor.save_pretrained(save_dir)
 ```
 
 A minute or two later, the model has been quantized. We can then easily load it with our [`OVModelForXxx`](https://huggingface.co/docs/optimum/intel/inference) classes, the equivalent of the Transformers [`AutoModelForXxx`](https://huggingface.co/docs/transformers/main/en/autoclass_tutorial#automodel) classes found in the `transformers` library. Likewise, we can create [pipelines](https://huggingface.co/docs/transformers/main/en/main_classes/pipelines) and run inference with [OpenVINO Runtime](https://docs.openvino.ai/latest/openvino_docs_OV_UG_OV_Runtime_User_Guide.html).
@@ -127,7 +128,7 @@ from transformers import pipeline
 from optimum.intel.openvino import OVModelForImageClassification
 ​
 ov_model = OVModelForImageClassification.from_pretrained(save_dir)
-ov_pipe = pipeline("image-classification", model=ov_model, feature_extractor=feature_extractor)
+ov_pipe = pipeline("image-classification", model=ov_model, image_processor=processor)
 outputs = ov_pipe("http://farm2.staticflickr.com/1375/1394861946_171ea43524_z.jpg")
 print(outputs)
 ```
@@ -149,7 +150,7 @@ ov_eval_results = task_evaluator.compute(
     label_mapping=ov_pipe.model.config.label2id,
 )
 
-trfs_pipe = pipeline("image-classification", model=model, feature_extractor=feature_extractor)
+trfs_pipe = pipeline("image-classification", model=model, processor=processor)
 trfs_eval_results = task_evaluator.compute(
     model_or_pipeline=trfs_pipe,
     data=eval_dataset,

--- a/openvino.md
+++ b/openvino.md
@@ -150,7 +150,7 @@ ov_eval_results = task_evaluator.compute(
     label_mapping=ov_pipe.model.config.label2id,
 )
 
-trfs_pipe = pipeline("image-classification", model=model, processor=processor)
+trfs_pipe = pipeline("image-classification", model=model, image_processor=processor)
 trfs_eval_results = task_evaluator.compute(
     model_or_pipeline=trfs_pipe,
     data=eval_dataset,

--- a/perceiver.md
+++ b/perceiver.md
@@ -155,19 +155,19 @@ class PerceiverForImageClassificationLearned(nn.Module):
         )
 ```
 
-One can see that `PerceiverImagePreprocessor` is initialized with `prep_type = "conv1x1"` and that one adds arguments for the trainable position encodings. So how does this preprocessor work in detail? Suppose that one provides a batch of images to the model. Let's say one applies center cropping to a resolution of 224 and normalization of the color channels first, such that the `inputs` are of shape (batch_size, num_channels, height, width) = (batch_size, 3, 224, 224). One can use `PerceiverFeatureExtractor` for this, as follows:
+One can see that `PerceiverImagePreprocessor` is initialized with `prep_type = "conv1x1"` and that one adds arguments for the trainable position encodings. So how does this preprocessor work in detail? Suppose that one provides a batch of images to the model. Let's say one applies center cropping to a resolution of 224 and normalization of the color channels first, such that the `inputs` are of shape (batch_size, num_channels, height, width) = (batch_size, 3, 224, 224). One can use `PerceiverImageProcessor` for this, as follows:
 
 ``` python
-from transformers import PerceiverFeatureExtractor
+from transformers import PerceiverImageProcessor
 import requests
 from PIL import Image
 
-feature_extractor = PerceiverFeatureExtractor.from_pretrained("deepmind/vision-perceiver")
+processor = PerceiverImageProcessor.from_pretrained("deepmind/vision-perceiver")
 
 url = 'http://images.cocodataset.org/val2017/000000039769.jpg'
 image = Image.open(requests.get(url, stream=True).raw)
 
-inputs = feature_extractor(image, return_tensors="pt").pixel_values
+inputs = processor(image, return_tensors="pt").pixel_values
 ```
 
 `PerceiverImagePreprocessor` (with the settings defined above) will first apply a convolutional layer with kernel size (1, 1) to turn the `inputs` into a tensor of shape (batch_size, 256, 224, 224) - hence increasing the channel dimension. It will then place the channel dimension last - so now one has a tensor of shape (batch_size, 224, 224, 256). Next, it flattens the spatial (height + width) dimensions such that one has a tensor of shape (batch_size, 50176, 256). Next, it concatenates it with trainable 1D position embeddings. As the dimensionality of the position embeddings is defined to be 256 (see the `num_channels` argument above), one is left with a tensor of shape (batch_size, 50176, 512). This tensor will be used for the cross-attention operation with the latents.

--- a/tf-serving-vision.md
+++ b/tf-serving-vision.md
@@ -102,23 +102,22 @@ steps include:
 
 - Resizing the image so that it has a spatial resolution of (224, 224).
 
-You can confirm these by investigating the feature extractor associated
+You can confirm these by investigating the image processor associated
 with the model:
 
 ```py
-from transformers import AutoFeatureExtractor
+from transformers import AutoImageProcessor
 
-feature_extractor = AutoFeatureExtractor.from_pretrained(ckpt)
-print(feature_extractor)
+processor = AutoImageProcessor.from_pretrained(ckpt)
+print(processor)
 ```
 
 This should print:
 
 ```bash
-ViTFeatureExtractor {
+ViTImageProcessor {
   "do_normalize": true,
   "do_resize": true,
-  "feature_extractor_type": "ViTFeatureExtractor",
   "image_mean": [
     0.5,
     0.5,
@@ -152,7 +151,7 @@ components:
 
 ```py
 def normalize_img(
-    img, mean=feature_extractor.image_mean, std=feature_extractor.image_std
+    img, mean=processor.image_mean, std=processor.image_std
 ):
     # Scale to the value range of [0, 1] first and then normalize.
     img = img / 255
@@ -167,11 +166,11 @@ Transformers. The below code snippet shows all the preprocessing steps:
 
 ```py
 CONCRETE_INPUT = "pixel_values" # Which is what we investigated via the SavedModel CLI.
-SIZE = feature_extractor.size
+SIZE = processor.size["height"]
 
 
 def normalize_img(
-    img, mean=feature_extractor.image_mean, std=feature_extractor.image_std
+    img, mean=processor.image_mean, std=processor.image_std
 ):
     # Scale to the value range of [0, 1] first and then normalize.
     img = img / 255

--- a/vision-transformers.md
+++ b/vision-transformers.md
@@ -103,7 +103,7 @@ This blog post will show how easy it is to fine-tune pre-trained Transformer mod
 <div style="font-size: 14px; line-height: 1.3;">
 <script src="https://gist.github.com/nickmaxfield/1df44cf80f72e1132441e539e3c3df84.js"></script>
 </div>
-<p>To fine-tune a pre-trained model, the new dataset must have the same properties as the original dataset used for pre-training. In Hugging Face, the original dataset information is provided in a config file loaded using the <code>AutoFeatureExtractor</code>. For this model, the X-ray images are resized to the correct resolution (224x224), converted from grayscale to RGB, and normalized across the RGB channels with a mean (0.5, 0.5, 0.5) and a standard deviation (0.5, 0.5, 0.5).</p>
+<p>To fine-tune a pre-trained model, the new dataset must have the same properties as the original dataset used for pre-training. In Hugging Face, the original dataset information is provided in a config file loaded using the <code>AutoImageProcessor</code>. For this model, the X-ray images are resized to the correct resolution (224x224), converted from grayscale to RGB, and normalized across the RGB channels with a mean (0.5, 0.5, 0.5) and a standard deviation (0.5, 0.5, 0.5).</p>
 <div style="font-size: 14px; line-height: 1.3;">
 <script src="https://gist.github.com/nickmaxfield/15c3fa337c2fd7e0b3cad23c421c3d28.js"></script>
 </div>

--- a/zh/image-similarity.md
+++ b/zh/image-similarity.md
@@ -52,11 +52,11 @@ translators:
 
 
 ```py
-from transformers import AutoFeatureExtractor, AutoModel
+from transformers import AutoImageProcessor, AutoModel
 
 
 model_ckpt = "nateraw/vit-base-beans"
-extractor = AutoFeatureExtractor.from_pretrained(model_ckpt)
+extractor = AutoImageProcessor.from_pretrained(model_ckpt)
 model = AutoModel.from_pretrained(model_ckpt)
 ```
 

--- a/zh/image-similarity.md
+++ b/zh/image-similarity.md
@@ -56,7 +56,7 @@ from transformers import AutoImageProcessor, AutoModel
 
 
 model_ckpt = "nateraw/vit-base-beans"
-extractor = AutoImageProcessor.from_pretrained(model_ckpt)
+processor = AutoImageProcessor.from_pretrained(model_ckpt)
 model = AutoModel.from_pretrained(model_ckpt)
 ```
 


### PR DESCRIPTION
I saw a lot of our blogs are using the deprecated `FeatureExtractor` class of Transformers for vision models, which is now called `ImageProcessor`.

Hence this PR updates and replaces all blogs to the up-to-date class.

cc @amyeroberts @rafaelpadilla 