### PR TITLE
Remove broken embedded space

### DIFF
--- a/gaussian-splatting.md
+++ b/gaussian-splatting.md
@@ -11,15 +11,6 @@ authors:
 
 3D Gaussian Splatting is a rasterization technique described in [3D Gaussian Splatting for Real-Time Radiance Field Rendering](https://huggingface.co/papers/2308.04079) that allows real-time rendering of photorealistic scenes learned from small samples of images. This article will break down how it works and what it means for the future of graphics.
 
-Check out the remote Gaussian Viewer space [here](https://huggingface.co/spaces/dylanebert/gaussian-viewer) or embedded below for an example of a Gaussian Splatting scene.
-
-<iframe
-	src="https://dylanebert-gaussian-viewer.hf.space"
-	frameborder="0"
-	width="960"
-	height="720"
-></iframe>
-
 ## What is 3D Gaussian Splatting?
 
 3D Gaussian Splatting is, at its core, a rasterization technique. That means:


### PR DESCRIPTION
Removing the embedded remote viewer space since the page still gets a lot of traffic, and the remote viewer space will not be indefinitely maintained