### PR TITLE
typo fix:pytorch ddp accelerate

### DIFF
--- a/pytorch-ddp-accelerate-transformers.md
+++ b/pytorch-ddp-accelerate-transformers.md
@@ -251,7 +251,7 @@ def train_ddp_accelerate():
     test_loader = torch.utils.data.DataLoader(test_dset, shuffle=False, batch_size=64)
 
     # Build model
-    model = BasicModel()
+    model = BasicNet()
 
     # Build optimizer
     optimizer = optim.AdamW(model.parameters(), lr=1e-3)
@@ -307,7 +307,7 @@ notebook_launcher(train_ddp, args=(), num_processes=2)
 Or:
 
 ```python
-notebook_launcher(train_accelerate_ddp, args=(), num_processes=2)
+notebook_launcher(train_ddp_accelerate, args=(), num_processes=2)
 ```
 
 ## Using 🤗 Trainer

--- a/zh/pytorch-ddp-accelerate-transformers.md
+++ b/zh/pytorch-ddp-accelerate-transformers.md
@@ -255,7 +255,7 @@ def train_ddp_accelerate():
     test_loader = torch.utils.data.DataLoader(test_dset, shuffle=False, batch_size=64)
 
     # Build model
-    model = BasicModel()
+    model = BasicNet()
 
     # Build optimizer
     optimizer = optim.AdamW(model.parameters(), lr=1e-3)
@@ -311,7 +311,7 @@ notebook_launcher(train_ddp, args=(), num_processes=2)
 或者：
 
 ```python
-notebook_launcher(train_accelerate_ddp, args=(), num_processes=2)
+notebook_launcher(train_ddp_accelerate, args=(), num_processes=2)
 ```
 
 ## 使用 🤗 Trainer


### PR DESCRIPTION
The [definition](https://github.com/huggingface/blog/blob/main/zh/pytorch-ddp-accelerate-transformers.md#:~:text=class%20BasicNet(nn.Module)%3A):
`python
class BasicNet(nn.Module):
    ...`
[typo](https://github.com/huggingface/blog/blob/main/zh/pytorch-ddp-accelerate-transformers.md#:~:text=%23%20Build%20model%0A%20%20%20%20model%20%3D%20BasicModel())
`python
    # Build model
    model = BasicModel()
`