### PR TITLE
Update codellama.md. Sample code fix.

### DIFF
--- a/codellama.md
+++ b/codellama.md
@@ -257,7 +257,7 @@ answer_2 = "answer_2"
 user_3 = "user_prompt_3"
 
 prompt  = f"<<SYS>>\\n{system}\\n<</SYS>>\\n\\n{user_1}"
-prompt += f"<s>[INST] {prompt.strip()} [/INST] {answer_1.strip()} </s>"
+prompt  = f"<s>[INST] {prompt.strip()} [/INST] {answer_1.strip()} </s>"
 prompt += f"<s>[INST] {user_2.strip()} [/INST] {answer_2.strip()} </s>"
 prompt += f"<s>[INST] {user_3.strip()} [/INST]"
 

--- a/codellama.md
+++ b/codellama.md
@@ -256,7 +256,7 @@ user_2 = "user_prompt_2"
 answer_2 = "answer_2"
 user_3 = "user_prompt_3"
 
-prompt  = f"<<SYS>>\\n{system}\\n<</SYS>>\\n\\n{user_1}"
+prompt  = f"<<SYS>>\n{system}\n<</SYS>>\n\n{user_1}"
 prompt  = f"<s>[INST] {prompt.strip()} [/INST] {answer_1.strip()} </s>"
 prompt += f"<s>[INST] {user_2.strip()} [/INST] {answer_2.strip()} </s>"
 prompt += f"<s>[INST] {user_3.strip()} [/INST]"


### PR DESCRIPTION
Fix the sample code for on-going conversation with codellama instruct model. Line 260 should not have suffix append instruction instead it should be a simple value assignment.

Existing code:
```python
system = "System prompt"
user_1 = "user_prompt_1"
answer_1 = "answer_1"
user_2 = "user_prompt_2"
answer_2 = "answer_2"
user_3 = "user_prompt_3"

prompt  = f"<<SYS>>\\n{system}\\n<</SYS>>\\n\\n{user_1}"
prompt += f"<s>[INST] {prompt.strip()} [/INST] {answer_1.strip()} </s>"
prompt += f"<s>[INST] {user_2.strip()} [/INST] {answer_2.strip()} </s>"
prompt += f"<s>[INST] {user_3.strip()} [/INST]"

inputs = tokenizer(prompt, return_tensors="pt", add_special_tokens=False).to("cuda")
```

Results in:
```
<<SYS>>
{system}
<</SYS>>

{user_1}<s>[INST] <<SYS>>
{system}
<</SYS>>

{user_1} [/INST] {answer_1.strip()} </s><s>[INST] {user_2.strip()} [/INST] {answer_2.strip()} </s><s>[INST] {user_3.strip()} [/INST]
```

Expected correct output:
```
<s>[INST] <<SYS>>
{system}
<</SYS>>

{user_1} [/INST] {answer_1.strip()} </s><s>[INST] {user_2.strip()} [/INST] {answer_2.strip()} </s><s>[INST] {user_3.strip()} [/INST]
```