### PR TITLE
Update pytorch-ddp-accelerate-transformers.md

### DIFF
--- a/pytorch-ddp-accelerate-transformers.md
+++ b/pytorch-ddp-accelerate-transformers.md
@@ -101,6 +101,7 @@ model.eval()
 correct = 0
 with torch.no_grad():
     for data, target in test_loader:
+        data, target = data.to(device), target.to(device)
         output = model(data)
         pred = output.argmax(dim=1, keepdim=True)
         correct += pred.eq(target.view_as(pred)).sum().item()


### PR DESCRIPTION
As the model is on 'cuda', the test data and labels also should be on the same device for evaluation. I guess this is just a copy paste issue