### PR TITLE
Change n to m for Y in Enc-Dec section

### DIFF
--- a/encoder-decoder.md
+++ b/encoder-decoder.md
@@ -366,10 +366,10 @@ $$ f_{\theta_{\text{enc}}}: \mathbf{X}_{1:n} \to \mathbf{\overline{X}}_{1:n}. $$
 
 The transformer-based decoder part then models the conditional
 probability distribution of the target vector sequence
-\\(\mathbf{Y}_{1:n}\\) given the sequence of encoded hidden states
+\\(\mathbf{Y}_{1:m}\\) given the sequence of encoded hidden states
 \\(\mathbf{\overline{X}}_{1:n}\\):
 
-$$ p_{\theta_{dec}}(\mathbf{Y}_{1:n} | \mathbf{\overline{X}}_{1:n}).$$
+$$ p_{\theta_{dec}}(\mathbf{Y}_{1:m} | \mathbf{\overline{X}}_{1:n}).$$
 
 By Bayes\' rule, this distribution can be factorized to a product of
 conditional probability distribution of the target vector \\(\mathbf{y}_i\\)
@@ -377,7 +377,7 @@ given the encoded hidden states \\(\mathbf{\overline{X}}_{1:n}\\) and all
 previous target vectors \\(\mathbf{Y}_{0:i-1}\\):
 
 $$
-p_{\theta_{dec}}(\mathbf{Y}_{1:n} | \mathbf{\overline{X}}_{1:n}) = \prod_{i=1}^{n} p_{\theta_{\text{dec}}}(\mathbf{y}_i | \mathbf{Y}_{0: i-1}, \mathbf{\overline{X}}_{1:n}). $$
+p_{\theta_{dec}}(\mathbf{Y}_{1:m} | \mathbf{\overline{X}}_{1:n}) = \prod_{i=1}^{m} p_{\theta_{\text{dec}}}(\mathbf{y}_i | \mathbf{Y}_{0: i-1}, \mathbf{\overline{X}}_{1:n}). $$
 
 The transformer-based decoder hereby maps the sequence of encoded hidden
 states \\(\mathbf{\overline{X}}_{1:n}\\) and all previous target vectors


### PR DESCRIPTION
In the Encoder-Decoder section, the output sequence is introduced as being of length m, i.e. $\mathbf{Y}_{1:m}$ but then inside the following equations, it is denoted as $\mathbf{Y}_{1:n}$, using the input sequence X's length $n$ instead. But $Y$ does not need to be the same length as $X$. Later in the article, in the decoder section, the formulas do use $m$ instead of $n$ as the length for $Y$.

So I believe this is just a mistake and have proposed a fix. Please do let me know if I am mistaken.

Post author: @patrickvonplaten 