### PR TITLE
Fix strikethrough in SetFit Optimum-Intel blogpost

### DIFF
--- a/setfit-optimum-intel.md
+++ b/setfit-optimum-intel.md
@@ -28,7 +28,7 @@ Compared to LLM based methods, SetFit has two unique advantages:
 
 For more details on SetFit, check out our [paper](https://arxiv.org/abs/2209.11055), [blog](https://huggingface.co/blog/setfit), [code](https://github.com/huggingface/setfit), and [data](https://huggingface.co/SetFit).
 
-Setfit has been widely adopted by the AI developer community, with ~100k downloads per month and [~1500](https://huggingface.co/models?library=setfit) SetFit models on the Hub, and growing with an average of ~4 models per day!
+Setfit has been widely adopted by the AI developer community, with \~100k downloads per month and [\~1500](https://huggingface.co/models?library=setfit) SetFit models on the Hub, and growing with an average of ~4 models per day!
 
 ## Faster!
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Fix strikethrough in [SetFit Optimum-Intel blogpost](https://huggingface.co/blog/setfit-optimum-intel)

## Details
The strikethrough is a bit unfortunate, it rendered differently for me locally: 
![image](https://github.com/huggingface/blog/assets/37621491/daff9665-a00d-4389-a8bd-047d4a42e651)

- Tom Aarsen