### PR TITLE
Add open-source-collab tag to SetFit optimum-Intel blogpost

### DIFF
--- a/_blog.yml
+++ b/_blog.yml
@@ -3705,3 +3705,4 @@
     - optimum
     - collaboration
     - community    
+    - open-source-collab


### PR DESCRIPTION
Hello!

## Pull Request overview
* As requested by Intel, add the `open-source-collab` tag to SetFit optimum-Intel blogpost

## Details
I think that perhaps the `collaboration` tag was replaced at some point? The intention is to also place the blogpost on this tab: https://huggingface.co/blog?tag=open-source-collab

- Tom Aarsen