### PR TITLE
Fixing a typo in the private-inference blog

### DIFF
--- a/fhe-endpoints.md
+++ b/fhe-endpoints.md
@@ -79,8 +79,8 @@ Lastly, your user machines need to have Concrete ML installed locally: Make a vi
 
 ```bash
 python3.10 -m venv .venv
-pip install -U setuptools pip wheel
 source .venv/bin/activate
+pip install -U setuptools pip wheel
 pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
Sorry @pcuenca , we've seen that two lines were inverted.