### PR TITLE
Update Matryoshka blogpost to use new Sentence Transformers v2.7.0 functionality

### DIFF
--- a/matryoshka.md
+++ b/matryoshka.md
@@ -127,7 +127,7 @@ Keep in mind that although processing smaller embeddings for downstream tasks (r
 
 ### In Sentence Transformers
 
-In Sentence Transformers, you can load a Matryoshka Embedding model like normal, and run inference with it using [`SentenceTransformers.encode`](https://sbert.net/docs/package_reference/SentenceTransformer.html#sentence_transformers.SentenceTransformer.encode). After getting the embeddings, we can truncate them to our desired size, and we can normalize them if we want.
+In Sentence Transformers, you can load a Matryoshka Embedding model just like any other model, but you can specify the desired embedding size using the `truncate_dim` argument. After that, you can perform inference using the [`SentenceTransformers.encode`](https://sbert.net/docs/package_reference/SentenceTransformer.html#sentence_transformers.SentenceTransformer.encode) function, and the embeddings will be automatically truncated to the specified size.
 
 Let's try to use a model that I trained using [`matryoshka_nli.py`](https://github.com/UKPLab/sentence-transformers/blob/master/examples/training/matryoshka/matryoshka_nli.py) with [`microsoft/mpnet-base`](https://huggingface.co/microsoft/mpnet-base):
 

--- a/matryoshka.md
+++ b/matryoshka.md
@@ -135,9 +135,9 @@ Let's try to use a model that I trained using [`matryoshka_nli.py`](https://gith
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.util import cos_sim
 
-model = SentenceTransformer("tomaarsen/mpnet-base-nli-matryoshka")
-
 matryoshka_dim = 64
+model = SentenceTransformer("tomaarsen/mpnet-base-nli-matryoshka", truncate_dim=matryoshka_dim)
+
 embeddings = model.encode(
     [
         "The weather is so nice!",
@@ -145,7 +145,6 @@ embeddings = model.encode(
         "He drove to the stadium.",
     ]
 )
-embeddings = embeddings[..., :matryoshka_dim]  # Shrink the embedding dimensions
 print(embeddings.shape)
 # => (3, 64)
 
@@ -167,6 +166,8 @@ References:
 * [Matryoshka Embeddings - Inference](https://sbert.net/examples/training/matryoshka/README.html#inference)
 
 <details><summary><b>Click here to see how to use the Nomic v1.5 Matryoshka Model</b></summary>
+
+Note: Nomic specifically requires an `F.layer_norm` before the embedding truncation. As a result, the following snippet uses manual truncation to the desired dimension. For all other models, you can use the `truncate_dim` option in the constructor.
 
 ```python
 from sentence_transformers import SentenceTransformer

--- a/matryoshka.md
+++ b/matryoshka.md
@@ -167,7 +167,7 @@ References:
 
 <details><summary><b>Click here to see how to use the Nomic v1.5 Matryoshka Model</b></summary>
 
-Note: Nomic specifically requires an `F.layer_norm` before the embedding truncation. As a result, the following snippet uses manual truncation to the desired dimension. For all other models, you can use the `truncate_dim` option in the constructor.
+Note: Nomic specifically requires an `F.layer_norm` before the embedding truncation. As a result, the following snippet uses manual truncation to the desired dimension. For all other models, you can use the `truncate_dim` option in the constructor, as shown in the previous example.
 
 ```python
 from sentence_transformers import SentenceTransformer


### PR DESCRIPTION
Hello!

## Pull Request overview
* Use new `truncate_dim` parameter in inference snippet.

## Details
This should help share the news for `truncate_dim`, which simplifies the usage of Matryoshka models, especially in third party applications where you can't manually post-process embeddings before they're used.

- Tom Aarsen