### PR TITLE
Add links to chatty idefics2 to the blogpost

### DIFF
--- a/idefics2.md
+++ b/idefics2.md
@@ -128,14 +128,14 @@ If you wish to deep dive further, here is the compilation of all resources for I
 * [Idefics2 collection](https://huggingface.co/collections/HuggingFaceM4/idefics2-661d1971b7c50831dd3ce0fe)
 * [Idefics2 model with model card](https://huggingface.co/HuggingFaceM4/idefics2-8b)
 * [Idefics2-base model with model card](https://huggingface.co/HuggingFaceM4/idefics2-8b-base)
-* Idefics2-chat model with model card (coming soon)
+* [Idefics2-chat model with model card](https://huggingface.co/HuggingFaceM4/idefics2-8b-chatty)
 * [The Cauldron with its dataset card](https://huggingface.co/datasets/HuggingFaceM4/the_cauldron)
 * [OBELICS with its dataset card](https://huggingface.co/datasets/HuggingFaceM4/OBELICS)
 * [WebSight with its dataset card](https://huggingface.co/datasets/HuggingFaceM4/WebSight)
 * [Idefics2 fine-tuning colab](https://colab.research.google.com/drive/1rm3AGquGEYXfeeizE40bbDtcWh5S4Nlq?usp=sharing)
 * [Idefics2-8B model demo (not the chatty model)](https://huggingface.co/spaces/HuggingFaceM4/idefics-8b)
-* Idefics2 demo: (coming soon)
-* Idefics2 paper: (coming soon)
+* [Idefics2 demo](https://huggingface.co/spaces/HuggingFaceM4/idefics2_playground)
+* [Idefics2 paper](https://arxiv.org/abs/2405.02246)
 
 
 ## License


### PR DESCRIPTION
This PR updates the blogpost on https://huggingface.co/blog/idefics2 with links to the chatty version of IDEFICS2