### PR TITLE
FIX TYPO: Simple variable change in LoraConfig

### DIFF
--- a/stackllama.md
+++ b/stackllama.md
@@ -105,7 +105,7 @@ lora_config = LoraConfig(
     task_type="CAUSAL_LM",
 )
 
-model = get_peft_model(model, config)
+model = get_peft_model(model, lora_config)
 ```
 
 We train the model for a few thousand steps with the causal language modeling objective and save the model. Since we will tune the model again with different objectives, we merge the adapter weights with the original model weights.


### PR DESCRIPTION
When loading get_peft_model the config passed was config but defined as lora_config. Just a typo fix!!