### PR TITLE
Fix typo in the Llama3.1 prompt template

### DIFF
--- a/llama31.md
+++ b/llama31.md
@@ -656,7 +656,7 @@ Llama 3.1 Instruct supports custom function calls from a single user message. Th
 ```
 <|begin_of_text|><|start_header_id|>system<|end_header_id|>
 
-You are a helpful assistant with tool calling capabilities. When you receive a tool call response, use the output to format an answer to the orginal user question.<|eot_id|><|start_header_id|>user<|end_header_id|>
+You are a helpful assistant with tool calling capabilities. When you receive a tool call response, use the output to format an answer to the original user question.<|eot_id|><|start_header_id|>user<|end_header_id|>
 
 Given the following functions, please respond with a JSON for a function call with its proper arguments that best answers the given prompt.
 


### PR DESCRIPTION
The llama 3.1 tool calling template says "orginal user question" instead of the "original user question". 

Unless it's the actual prompt pattern the model is trained with, this should affect the tool use performance; and I see this typo spreading to other tutorials and tools using Llama 3.1