### PR TITLE
fixes: the video link of gradio5

### DIFF
--- a/gradio-5.md
+++ b/gradio-5.md
@@ -40,7 +40,7 @@ Our goal with Gradio 5 was to listen to and address the most common pain points 
 *   "LLMs don't know Gradio" → Gradio 5 ships with an experimental AI Playground where you can use AI to generate or modify Gradio apps and preview the app right in your browser immediately: [https://www.gradio.app/playground](https://www.gradio.app/playground) 
 
 <video width="600" controls>
-  <source src="https://huggingface.co/datasets/huggingface/documentation-images/raw/main/blog/gradio-5/simple-playground.mp4">
+  <source src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/blog/gradio-5/simple-playground.mp4">
 </video>
 
 Gradio 5 provides all these features while maintaining Gradio’s simple and intuitive developer-facing API. Since Gradio 5 intended to be a production-ready web framework for all kinds of machine learning applications, we've also made significant improvements around web security (including getting a 3rd-party audit of Gradio) -- more about that in an upcoming post!


### PR DESCRIPTION
Hi @abidlabs 

I've update the video link for the 2nd video demo of Gradio 5, since the existing link seems broken on the blog page.

cc/ @xianbaoqian @adeenayakup 

Thanks!
Luke