### PR TITLE
Update encoder-decoder.md

### DIFF
--- a/encoder-decoder.md
+++ b/encoder-decoder.md
@@ -352,7 +352,7 @@ mapping.
 
 Similar to RNN-based encoder-decoder models, the transformer-based
 encoder-decoder models define a conditional distribution of target
-vectors \\(\mathbf{Y}_{1:n}\\) given an input sequence \\(\mathbf{X}_{1:n}\\):
+vectors \\(\mathbf{Y}_{1:m}\\) given an input sequence \\(\mathbf{X}_{1:n}\\):
 
 $$
 p_{\theta_{\text{enc}}, \theta_{\text{dec}}}(\mathbf{Y}_{1:m} | \mathbf{X}_{1:n}).


### PR DESCRIPTION
Congratulations! You've made it this far! Once merged, the article will appear at https://huggingface.co/blog. Official articles 
require additional reviews. Alternatively, you can write a community article following the process [here](https://huggingface.co/blog-explorers).

## Preparing the Article

You're not quite done yet, though. Please make sure to follow this process (as documented [here](https://github.com/huggingface/blog/tree/main?tab=readme-ov-file#how-to-write-an-article-)):

- [ ] Add an entry to [_blog.yml](https://github.com/huggingface/blog/blob/main/_blog.yml).
- [ ] Add a thumbnail. There are no requirements here, but there is a [template](https://github.com/huggingface/blog?tab=readme-ov-file#how-to-get-a-nice-responsive-thumbnail) if it's helpful.
- [ ] Check you use a short title and blog path.
- [ ] Upload any additional assets (such as images) to the Documentation Images [repo](https://huggingface.co/datasets/huggingface/documentation-images/tree/main/blog). This is to reduce bloat in the GitHub base repo when cloning and pulling. Try to have small images to avoid a slow or expensive user experience.
- [ ] Add metadata (such as authors) to your `md` file. You can also specify `guest` or `org` for the authors.
- [ ] Ensure the publication date is correct.
- [ ] Preview the content. A quick way is to paste the markdown content in https://huggingface.co/new-blog. **Do not click publish**, this is just a way to do an early check.

Here is an example of a complete PR: https://github.com/huggingface/blog/pull/2382

## Getting a Review

Please make sure to get a review from someone on your team or a co-author.
Once this is done and once all the steps above are completed, you should be able to merge.
There is no need for additional reviews if you and your co-authors are happy and meet all of the above.

Feel free to add @osanseviero or @pcuenca as reviewers if you want a final check. They'll be biased toward light reviews
(e.g., check for proper metadata) rather than content reviews unless explicitly asked. 

