### PR TITLE
Add formal citation for existing speculative decoding paper

### DIFF
--- a/dynamic_speculation_lookahead.md
+++ b/dynamic_speculation_lookahead.md
@@ -134,3 +134,13 @@ In an upcoming blog post, we'll show a new method for assisted generation: combi
 In this paper, we introduced DISCO, a dynamic speculation lookahead optimization method that utilizes a classifier to decide whether the draft model should proceed with generating the next token or pause, and switch to the target model for validation instead of using a simple threshold on the prediction probability.
 - [Assisted Generation: a new direction toward low-latency text generation](https://huggingface.co/blog/assisted-generation)
 - [Fast Inference from Transformers via Speculative Decoding](https://arxiv.org/pdf/2211.17192)
+
+## Citation
+```bibtex
+@article{mamou2024accelerating,
+  title={Accelerating Speculative Decoding using Dynamic Speculation Length},
+  author={Mamou, Jonathan and Pereg, Oren and Korat, Daniel and Berchansky, Moshe and Timor, Nadav and Wasserblat, Moshe and Schwartz, Roy},
+  journal={arXiv preprint arXiv:2405.04304},
+  year={2024}
+}
+```


### PR DESCRIPTION
This pull request updates the blog post "Dynamic Speculation Lookahead Optimization" by adding a formal citation for the existing paper already linked.

**Summary of changes:**
Added a citation block to the bottom of the post to formally reference the paper, following the citation style used in similar posts on the Hugging Face blog.

**Rationale:**
Including a full citation provides consistency with other posts and facilitates easy referencing for readers.

Please review and let me know if there are any further changes or enhancements needed. Thank you!