### PR TITLE
[FIX] Resolves compilation error in demo.c

### DIFF
--- a/introduction-to-ggml.md
+++ b/introduction-to-ggml.md
@@ -130,6 +130,7 @@ Edit `examples/demo/demo.c` with the content below:
 
 ```c
 #include "ggml.h"
+#include "ggml-cpu.h"
 #include <string.h>
 #include <stdio.h>
 

--- a/zh/introduction-to-ggml.md
+++ b/zh/introduction-to-ggml.md
@@ -134,6 +134,7 @@ touch examples/demo/CMakeLists.txt
 
 ```c
 #include "ggml.h"
+#include "ggml-cpu.h"
 #include <string.h>
 #include <stdio.h>
 


### PR DESCRIPTION
Add missing header for ggml_graph_compute_with_ctx function

the error :
`demo/demo.c:59:5: error: call to undeclared function 'ggml_graph_compute_with_ctx'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]`


