### PR TITLE
Update big-bench-audio-release.md

### DIFF
--- a/big-bench-audio-release.md
+++ b/big-bench-audio-release.md
@@ -42,7 +42,7 @@ Each question in the dataset is structured as:
 ```
 
 
-The audio files were generated using **23 synthetic voices** from top-ranked Text to Speech models in the **[Artifical Analysis Speech Arena](https://artificialanalysis.ai/text-to-speech/arena?tab=Leaderboard)**. Each audio generation was rigorously verified using Levenshtein distance against transcriptions, and edge cases were reviewed manually. To find out more about how the dataset was created, check out the **[dataset card](https://huggingface.co/datasets/ArtificialAnalysis/big_bench_audio)**.
+The audio files were generated using **23 synthetic voices** from top-ranked Text to Speech models in the **[Artificial Analysis Speech Arena](https://artificialanalysis.ai/text-to-speech/arena?tab=Leaderboard)**. Each audio generation was rigorously verified using Levenshtein distance against transcriptions, and edge cases were reviewed manually. To find out more about how the dataset was created, check out the **[dataset card](https://huggingface.co/datasets/ArtificialAnalysis/big_bench_audio)**.
 
 
 ## Evaluating Audio Reasoning


### PR DESCRIPTION
fix: correct typo "Artifical" → "Artificial" in speech arena reference

- Replaces the incorrect "Artifical Analysis Speech Arena" with "Artificial Analysis Speech Arena"