### PR TITLE
Fix code snippet not ending in Inference Providers blog

### DIFF
--- a/inference-providers.md
+++ b/inference-providers.md
@@ -114,6 +114,7 @@ image = client.text_to_image(
     "Labrador in the style of Vermeer",
     model="black-forest-labs/FLUX.1-dev"
 )
+```
 
 To move to a different provider, you can simply change the provider name, everything else stays the same:
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Fix code snippet not ending in Inference Providers blog

## Details
This was before:
![image](https://github.com/user-attachments/assets/9133ba9b-c72e-4896-b229-0930770fec78)


- Tom Aarsen