### PR TITLE
Update proxy url in inference providers blog

### DIFF
--- a/inference-providers.md
+++ b/inference-providers.md
@@ -152,12 +152,12 @@ console.log(chatCompletion.choices[0].message);
 
 ### From HTTP calls
 
-We expose the Routing proxy directly under the huggingface.co domain so you can call it directly, it's very useful for OpenAI-compatible APIs for instance. You can just swap the URL as a base URL: `https://huggingface.co/api/inference-proxy/{:provider}`.
+We expose the Routing proxy directly under the huggingface.co domain so you can call it directly, it's very useful for OpenAI-compatible APIs for instance. You can just swap the URL as a base URL: `https://router.huggingface.co/{:provider}`.
 
 Here's how you can call Llama-3.3-70B-Instruct using Sambanova as the inference provider via cURL.
 
 ```bash
-curl 'https://huggingface.co/api/inference-proxy/sambanova/v1/chat/completions' \
+curl 'https://router.huggingface.co/sambanova/v1/chat/completions' \
 -H 'Authorization: Bearer xxxxxxxxxxxxxxxxxxxxxxxx' \
 -H 'Content-Type: application/json' \
 --data '{

--- a/inference-providers.md
+++ b/inference-providers.md
@@ -161,7 +161,7 @@ curl 'https://router.huggingface.co/sambanova/v1/chat/completions' \
 -H 'Authorization: Bearer xxxxxxxxxxxxxxxxxxxxxxxx' \
 -H 'Content-Type: application/json' \
 --data '{
-    "model": "meta-llama/Llama-3.3-70B-Instruct",
+    "model": "Llama-3.3-70B-Instruct",
     "messages": [
 		{
 			"role": "user",


### PR DESCRIPTION
Follow-up after https://github.com/huggingface-internal/moon-landing/pull/12434 (internal link).
URL for routed requests (i.e. the inference proxy) got updated to `https://router.huggingface.co/{:provider}`. This PR updates the initial blog post for consistency.