### PR TITLE
Fixed moved link to agentic web browser example 

### DIFF
--- a/smolagents-can-see.md
+++ b/smolagents-can-see.md
@@ -315,7 +315,7 @@ Note, however, that this task is really hard: depending on the VLM that you use,
 
 This will give you a glimpse of the capabilities of a vision-enabled `CodeAgent`, but there’s much more to do!
 
-- You can get started with the agentic web browser [here](https://github.com/huggingface/smolagents/blob/main/examples/vlm_web_browser.py).
+- You can get started with the agentic web browser [here](https://huggingface.co/docs/smolagents/examples/web_browser).
 - Read more about smolagents [in our announcement blog post](https://huggingface.co/blog/smolagents).
 - Read [the smolagents documentation](https://huggingface.co/docs/smolagents/index).
 


### PR DESCRIPTION
In [We just gave sight to smolagents](https://huggingface.co/blog/smolagents-can-see), there is a broken link in

```
You can get started with the agentic web browser [here](https://github.com/huggingface/smolagents/blob/main/examples/vlm_web_browser.py).
```

since it was moved to https://huggingface.co/docs/smolagents/examples/web_browser

@aymeric-roucher