### PR TITLE
Update smolvlm.md

### DIFF
--- a/smolvlm.md
+++ b/smolvlm.md
@@ -146,7 +146,7 @@ SmolVLM's tiny memory footprint also implies that it requires far fewer computat
 
 Given SmolVLM's long context and the possibility of tweaking the internal frame resizing of the model, we explored its suitability as an accessible option for basic video analysis tasks, particularly when computational resources are limited.
 
-In our evaluation of SmolVLM's video understanding capabilities, we implemented a straightforward [video processing pipeline code](https://github.com/huggingface/smollm/blob/main/inference/smolvlm/SmolVLM_video_inference.py), extracting up to 50 evenly sampled frames from each video while avoiding internal frame resizing.
+In our evaluation of SmolVLM's video understanding capabilities, we implemented a straightforward [video processing pipeline code](https://github.com/huggingface/smollm/blob/main/tools/smolvlm_local_inference/SmolVLM_video_inference.py), extracting up to 50 evenly sampled frames from each video while avoiding internal frame resizing.
 This simple approach yielded surprisingly competitive results on the CinePile benchmark, with a score of 27.14%, a performance that positions the model between InternVL2 (2B) and Video LlaVa (7B).
 
 


### PR DESCRIPTION
This small PR updates the link to `SmolVLM_video_inference.py` in the smolVLM announcement blog post a script referenced in the Video section.

The location linked to in the post no longer exists due to a recent refactor of the smollm repo, this PR provides the updated link to reflect its new location.


