### PR TITLE
adding xet-team org to other xet posts

### DIFF
--- a/from-files-to-chunks.md
+++ b/from-files-to-chunks.md
@@ -3,7 +3,9 @@ title: "From Files to Chunks: Improving HF Storage Efficiency"
 thumbnail: /blog/assets/from-files-to-chunks/thumbnail.png
 authors:
   - user: jsulz
+    org: xet-team
   - user: erinys
+    org: xet-team
 ---
 
 # From Files to Chunks: Improving HF Storage Efficiency

--- a/rearchitecting-uploads-and-downloads.md
+++ b/rearchitecting-uploads-and-downloads.md
@@ -3,8 +3,11 @@ title: "Rearchitecting Hugging Face Uploads and Downloads"
 thumbnail: /blog/assets/rearchitecting-uploads-and-downloads/thumbnail.png
 authors:
   - user: port8080
+    org: xet-team
   - user: jsulz
+    org: xet-team
   - user: erinys
+    org: xet-team
 ---
 
 # Rearchitecting Hugging Face Uploads and Downloads


### PR DESCRIPTION
Adding `org: xet-team` to other posts from the team to fill out this on our [organization page](https://huggingface.co/xet-team) a bit more:



![blogpr](https://github.com/user-attachments/assets/49e7eaa3-bfbd-463c-8a3a-2fdb49dd330c)

P.S., sorry for the diff on the `improve_parquet_dedupe.md` file. Just a markdown linter cleaning up some spaces. 