### PR TITLE
fix model name for Fireworks in cURL snippet

### DIFF
--- a/fireworks-ai.md
+++ b/fireworks-ai.md
@@ -106,7 +106,7 @@ curl 'https://router.huggingface.co/fireworks-ai/v1/chat/completions' \
 -H 'Authorization: Bearer xxxxxxxxxxxxxxxxxxxxxxxx' \
 -H 'Content-Type: application/json' \
 --data '{
-    "model": "Llama-3.3-70B-Instruct",
+    "model": "accounts/fireworks/models/llama-v3p3-70b-instruct",
     "messages": [
         {
             "role": "user",


### PR DESCRIPTION
correct cURL should be

```curl
curl 'https://router.huggingface.co/fireworks-ai/v1/chat/completions' \
-H 'Authorization: Bearer xxxxxxxxxxxxxxxxxxxxxxxx' \
-H 'Content-Type: application/json' \
--data '{
    "model": "accounts/fireworks/models/llama-v3p3-70b-instruct",
    "messages": [
        {
            "role": "user",
            "content": "What is the meaning of life if you were a dog?"
        }
    ],
    "max_tokens": 500,
    "stream": false
}'
```