### PR TITLE
Update a link to Nebius AI Studio

### DIFF
--- a/inference-providers-nebius-novita-hyperbolic.md
+++ b/inference-providers-nebius-novita-hyperbolic.md
@@ -17,7 +17,7 @@ authors:
   org: Hyperbolic
 ---
 
-We’re thrilled to announce the addition of three more outstanding serverless Inference Providers to the Hugging Face Hub: [Hyperbolic](https://hyperbolic.xyz/), [Nebius AI Studio](https://nebius.com/), and [Novita](https://novita.ai/). These providers join our growing ecosystem, enhancing the breadth and capabilities of serverless inference directly on the Hub’s model pages. They’re also seamlessly integrated into our client SDKs (for both JS and Python), making it super easy to use a wide variety of models with your preferred providers.
+We’re thrilled to announce the addition of three more outstanding serverless Inference Providers to the Hugging Face Hub: [Hyperbolic](https://hyperbolic.xyz/), [Nebius AI Studio](https://studio.nebius.com/), and [Novita](https://novita.ai/). These providers join our growing ecosystem, enhancing the breadth and capabilities of serverless inference directly on the Hub’s model pages. They’re also seamlessly integrated into our client SDKs (for both JS and Python), making it super easy to use a wide variety of models with your preferred providers.
 
 These partners join the ranks of our existing providers, including Together AI, Sambanova, Replicate, fal and Fireworks.ai.
 
@@ -88,7 +88,7 @@ print(completion.choices[0].message)
 ```
 
 
-And here's how to generate an image from a text prompt using [FLUX.1-dev](https://huggingface.co/black-forest-labs/FLUX.1-dev) running on [Nebius AI Studio](https://nebius.com):
+And here's how to generate an image from a text prompt using [FLUX.1-dev](https://huggingface.co/black-forest-labs/FLUX.1-dev) running on [Nebius AI Studio](https://studio.nebius.com):
 
 ```python
 from huggingface_hub import InferenceClient


### PR DESCRIPTION
I am correcting the link to the Nebius AI Studio website to lead specifically to the inference service.

Page: https://huggingface.co/blog/inference-providers-nebius-novita-hyperbolic