### PR TITLE
Sentence Transformers Reranker - typo

### DIFF
--- a/train-reranker.md
+++ b/train-reranker.md
@@ -187,7 +187,7 @@ A concise example is:
 * **Soft Negative**: The Cache River Bridge is a Parker pony truss that spans the Cache River between Walnut Ridge and Paragould, Arkansas.
 * **Hard Negative**: The Fuji apple is an apple cultivar developed in the late 1930s, and brought to market in 1962.
 
-The strongest CrossEncoder models are generally trained to recognize hard negatives, and so it's valuable to be able to "mine" hard negatives to train the with. Sentence Transformers supports a strong [`mine_hard_negatives`](https://sbert.net/docs/package_reference/util.html#sentence_transformers.util.mine_hard_negatives) function that can assist, given a dataset of query-answer pairs:
+The strongest CrossEncoder models are generally trained to recognize hard negatives, and so it's valuable to be able to "mine" hard negatives to train with. Sentence Transformers supports a strong [`mine_hard_negatives`](https://sbert.net/docs/package_reference/util.html#sentence_transformers.util.mine_hard_negatives) function that can assist, given a dataset of query-answer pairs:
 
 ```python
 from datasets import load_dataset


### PR DESCRIPTION
Hello!

## Pull Request overview
* Sentence Transformers Reranker - typo

## Details
This fixes a typo in the ST Reranker blogpost

- Tom Aarsen