### PR TITLE
Fix typos for tgi gaudi blogpost

### DIFF
--- a/_blog.yml
+++ b/_blog.yml
@@ -5764,7 +5764,7 @@
 - local: intel-gaudi-backend-for-tgi
   title: "Accelerating LLM Inference with TGI on Intel Gaudi"
   author: baptistecolle
-  thumbnail: /blog/assets/optimum_intel/intel_thumbnail.png
+  thumbnail: /blog/assets/intel-gaudi-backend-for-tgi/tgi-gaudi-thumbnail.png
   date: March 28, 2025
   tags:
     - tgi

--- a/intel-gaudi-backend-for-tgi.md
+++ b/intel-gaudi-backend-for-tgi.md
@@ -8,7 +8,7 @@ authors:
 - user: echarlaix
 - user: kding1
   guest: true
-  org: intel
+  org: Intel
 ---
 
 # 🚀 Accelerating LLM Inference with TGI on Intel Gaudi


### PR DESCRIPTION
1.	I forgot to sync the thumbnail in _blog.yml with the blog post: https://github.com/huggingface/blog/blob/746d6aa230246f145e60b8ced8c9fd65a65deec7/intel-gaudi-backend-for-tgi.md?plain=1#L3

2.	The Intel badge is not rendering properly 
- What I did:
https://github.com/huggingface/blog/blob/746d6aa230246f145e60b8ced8c9fd65a65deec7/intel-gaudi-backend-for-tgi.md?plain=1#L11
- What is on the `intel-gcp-c4` blog:
https://github.com/huggingface/blog/blob/746d6aa230246f145e60b8ced8c9fd65a65deec7/intel-gcp-c4.md?plain=1#L10


In this blog post, the Intel badge appears next to Ke Ding: [Intel GCP C4](https://huggingface.co/blog/intel-gcp-c4), but it is missing from the new [Intel Gaudi Backend for TGI](https://huggingface.co/blog/intel-gaudi-backend-for-tgi)