### PR TITLE
[from Codex] Fix typos in recent posts

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -112,7 +112,7 @@ Well, we can do this by giving our agent an access to these parameters!
 
 Let's setup this system. 
 
-Tun the line below to install required dependancies:
+Run the line below to install the required dependencies:
 ```
 pip install langchain sentence-transformers faiss-cpu
 ```

--- a/fine-tune-w2v2-bert.md
+++ b/fine-tune-w2v2-bert.md
@@ -555,7 +555,7 @@ class DataCollatorCTCWithPadding:
     padding: Union[bool, str] = True
 
     def __call__(self, features: List[Dict[str, Union[List[int], torch.Tensor]]]) -> Dict[str, torch.Tensor]:
-        # split inputs and labels since they have to be of different lenghts and need
+        # split inputs and labels since they have to be of different lengths and need
         # different padding methods
         input_features = [{"input_features": feature["input_features"]} for feature in features]
         label_features = [{"input_ids": feature["labels"]} for feature in features]

--- a/matryoshka.md
+++ b/matryoshka.md
@@ -75,7 +75,7 @@ In practice, this incentivizes the model to frontload the most important informa
 
 ### In Sentence Transformers
 
-[Sentence Tranformers](https://sbert.net) is a commonly used framework to train embedding models, and it recently implemented support for Matryoshka models. Training a Matryoshka embedding model using Sentence Transformers is quite elementary: rather than applying some loss function on only the full-size embeddings, we also apply that same loss function on truncated portions of the embeddings.
+[Sentence Transformers](https://sbert.net) is a commonly used framework to train embedding models, and it recently implemented support for Matryoshka models. Training a Matryoshka embedding model using Sentence Transformers is quite elementary: rather than applying some loss function on only the full-size embeddings, we also apply that same loss function on truncated portions of the embeddings.
 
 For example, if a model has an original embedding dimension of 768, it can now be trained on 768, 512, 256, 128 and 64. Each of these losses will be added together, optionally with some weight:
 

--- a/python-tiny-agents.md
+++ b/python-tiny-agents.md
@@ -286,7 +286,7 @@ With the `MCPClient` doing all the job for tool interactions, our `Agent` class 
 > [!TIP]
 > The Agent class is tiny and focuses on the conversational loop, the code can be found [here](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/inference/_mcp/agent.py). 
 
-### 1. Intializing the Agent
+### 1. Initializing the Agent
 
 When an Agent is created, it takes an agent config (model, provider, which MCP servers to use, system prompt) and initializes the conversation history with the system prompt. The `load_tools()` method then iterates through the server configurations (defined in agent.json) and calls `add_mcp_server` (from the parent `MCPClient`) for each one, populating the agent's toolbox.
 

--- a/train-sentence-transformers.md
+++ b/train-sentence-transformers.md
@@ -196,7 +196,7 @@ Note that `eval_strategy` was introduced in `transformers` version `4.41.0`. Pri
 
 You can provide the [`SentenceTransformerTrainer`](https://sbert.net/docs/package_reference/sentence_transformer/SentenceTransformer.html#sentence_transformers.SentenceTransformer) with an `eval_dataset` to get the evaluation loss during training, but it may be useful to get more concrete metrics during training, too. For this, you can use evaluators to assess the model's performance with useful metrics before, during, or after training. You can both an `eval_dataset` and an evaluator, one or the other, or neither. They evaluate based on the `eval_strategy` and `eval_steps` [Training Arguments](#training-arguments).
 
-Here are the implemented Evaluators that come with Sentence Tranformers:
+Here are the implemented Evaluators that come with Sentence Transformers:
 
 | Evaluator | Required Data |
 | --- | --- |


### PR DESCRIPTION
## Summary
- fix agent setup instruction in `agents.md`
- correct heading spelling in `python-tiny-agents.md`
- fix typos in `matryoshka.md`, `train-sentence-transformers.md`, and `fine-tune-w2v2-bert.md`

## Testing
- `pre-commit` *(fails: command not found)*