### PR TITLE
Add scaling factor to attention score calculation in kv-cache.md

### DIFF
--- a/kv-cache.md
+++ b/kv-cache.md
@@ -85,8 +85,10 @@ Here’s a minimal PyTorch equivalent using a causal mask:
 
 ```python
 import torch.nn.functional as F
+import math
 
-attention_scores = Q @ K.T
+d_k = K.shape[-1]
+attention_scores = (Q @ K.T) / math.sqrt(d_k)
 
 # Lower triangular mask to prevent future token access
 causal_mask = torch.tril(torch.ones(input_seq_length, input_seq_length))


### PR DESCRIPTION
The PyTorch code example for attention calculation was missing the `1/√d_k` scaling factor that is correctly shown in the mathematical formula above it. This scaling prevents dot products from growing too large and helps control the softmax saturation region.

**Changes:**
- Added `import math` 
- Added scaling factor `/ math.sqrt(d_k)` to attention scores calculation
- Added `d_k = K.shape[-1]` to compute key dimension

The code now matches the mathematical formula: `softmax(QK^T / √d_k)V`

@ariG23498 