### PR TITLE
Update gemma3n.md to fix broken links

### DIFF
--- a/gemma3n.md
+++ b/gemma3n.md
@@ -31,8 +31,8 @@ These models, therefore, behave like 2B and 4B in terms of hardware support, but
 
 | Size | Base | Instruct |
 | :---- | :---- | :---- |
-| 2B | [google/gemma-3n-e2b](hf.co/google/gemma-3n-e2b) | [google/gemma-3n-e2b-it](hf.co/google/gemma-3n-e2b-it) |
-| 4B | [google/gemma-3n-e4b](hf.co/google/gemma-3n-e4b) | [google/gemma-3n-e4b-it](hf.co/google/gemma-3n-e4b-it) |
+| 2B | [google/gemma-3n-e2b](https://hf.co/google/gemma-3n-e2b) | [google/gemma-3n-e2b-it](https://hf.co/google/gemma-3n-e2b-it) |
+| 4B | [google/gemma-3n-e4b](https://hf.co/google/gemma-3n-e4b) | [google/gemma-3n-e4b-it](https://hf.co/google/gemma-3n-e4b-it) |
 
 ## Details of the models
 


### PR DESCRIPTION
without the https:// part the links in the blog redirect to https://huggingface.co/blog/hf.co/google/gemma-3n-e4b-it