### PR TITLE
Update tiny-agents example

### DIFF
--- a/python-tiny-agents.md
+++ b/python-tiny-agents.md
@@ -97,10 +97,8 @@ In this example, a "stdio" MCP server is configured. This type of server runs as
 	"servers": [
 		{
 			"type": "stdio",
-			"config": {
-				"command": "npx",
-				"args": ["@playwright/mcp@latest"]
-			}
+			"command": "npx",
+			"args": ["@playwright/mcp@latest"]
 		}
 	]
 }
@@ -315,7 +313,7 @@ class Agent(MCPClient):
     async def load_tools(self) -> None:
         # Connect to all configured MCP servers and register their tools
         for cfg in self._servers_cfg:
-            await self.add_mcp_server(cfg["type"], **cfg["config"])
+            await self.add_mcp_server(**cfg)
 
 ```
 


### PR DESCRIPTION
From @julien-c 's comment: https://github.com/huggingface/hub-docs/pull/1816#pullrequestreview-2994020075
---

Fix docs example after https://github.com/huggingface/huggingface_hub/pull/3166 / https://github.com/huggingface/huggingface.js/pull/1556. Since release [0.33.2](https://github.com/huggingface/huggingface_hub/releases/tag/v0.33.2) `tiny-agents` config follow VSCode format. We made the change without a proper deprecation warning as it's still experimental and we wanted to harmonize with VSCode as quickly as possible (to avoid future conflicts).  

Related PRs:
- https://github.com/huggingface/hub-docs/pull/1816
- https://github.com/huggingface/transformers/pull/39245
- https://github.com/huggingface/huggingface_hub/pull/3205
- https://github.com/huggingface/huggingface.js/pull/1599