### PR TITLE
fix: Correct indentation in usage example

### DIFF
--- a/trackio.md
+++ b/trackio.md
@@ -84,7 +84,7 @@ def simulate_multiple_runs():
                 "val_accuracy": val_acc
             })
             time.sleep(0.2)
-    trackio.finish()
+        trackio.finish()
 
 simulate_multiple_runs()
 ```


### PR DESCRIPTION
The 'trackio.finish()' call in the simulate_multiple_runs example was incorrectly placed outside the main loop. This change moves it inside the loop to correctly finalize each run after its epochs are completed, reflecting the proper usage pattern.