### PR TITLE
Add Demo Link for `Fast LoRA inference for Flux with Diffusers and PEFT`

### DIFF
--- a/lora-fast.md
+++ b/lora-fast.md
@@ -194,6 +194,11 @@ For consumer GPUs, specifically the RTX 4090, we tackled memory limitations by i
 Hopefully, the recipes from this post will inspire you to optimize your
 LoRA-based use cases, benefitting from speedy inference.
 
+## Note
+For readers interested in trying this approach, a deployed demo by [Parag Ekbote](https://github.com/ParagEkbote) is available on[Replicate](https://replicate.com/paragekbote/flux-fast-lora-hotswap). 
+
+This demo has been designed and tested on NVIDIA L40 and A100 GPUs, demonstrating comparable performance.
+
 ## Resources
 
 Below is a list of the important resources that we cited throughout this post:

--- a/lora-fast.md
+++ b/lora-fast.md
@@ -194,10 +194,6 @@ For consumer GPUs, specifically the RTX 4090, we tackled memory limitations by i
 Hopefully, the recipes from this post will inspire you to optimize your
 LoRA-based use cases, benefitting from speedy inference.
 
-## Note
-For readers interested in trying this approach, a deployed demo by [Parag Ekbote](https://github.com/ParagEkbote) is available on[Replicate](https://replicate.com/paragekbote/flux-fast-lora-hotswap). 
-
-This demo has been designed and tested on NVIDIA L40 and A100 GPUs, demonstrating comparable performance.
 
 ## Resources
 
@@ -206,3 +202,4 @@ Below is a list of the important resources that we cited throughout this post:
 * [Presenting Flux Fast: Making Flux go brrr on H100s](https://pytorch.org/blog/presenting-flux-fast-making-flux-go-brrr-on-h100s/)
 * [torch.compile and Diffusers: A Hands-On Guide to Peak Performance](https://pytorch.org/blog/torch-compile-and-diffusers-a-hands-on-guide-to-peak-performance/)
 * [LoRA guide in Diffusers](https://huggingface.co/docs/diffusers/main/en/tutorials/using_peft_for_inference)
+* For readers interested in trying this approach, a deployed demo by [Parag Ekbote](https://github.com/ParagEkbote) is available on [Replicate](https://replicate.com/paragekbote/flux-fast-lora-hotswap). This demo has been designed and tested on NVIDIA L40 and A100 GPUs, demonstrating comparable performance.

--- a/lora-fast.md
+++ b/lora-fast.md
@@ -194,7 +194,6 @@ For consumer GPUs, specifically the RTX 4090, we tackled memory limitations by i
 Hopefully, the recipes from this post will inspire you to optimize your
 LoRA-based use cases, benefitting from speedy inference.
 
-
 ## Resources
 
 Below is a list of the important resources that we cited throughout this post:


### PR DESCRIPTION
As discussed, I've included the demo link in a separate note at the end of the article. Could you please review?

cc: @sayakpaul , @BenjaminBossan