### PR TITLE
Fix missing CohereLabs badge with `orgs` metadata

### DIFF
--- a/aya-expanse.md
+++ b/aya-expanse.md
@@ -4,16 +4,14 @@ thumbnail: /blog/assets/aya-expanse/thumbnail.jpg
 authors:
 - user: johndang-cohere
   guest: true
-  org: CohereForAI
 - user: shivalikasingh
   guest: true
-  org: CohereForAI
 - user: dsouzadaniel
   guest: true
-  org: CohereForAI
 - user: ArashAhmadian
   guest: true
-  org: CohereForAI
+orgs:
+- CohereLabs
 ---
 
 # A Deepdive into Aya Expanse: Advancing the Frontier of Multilinguality

--- a/aya-vision.md
+++ b/aya-vision.md
@@ -4,16 +4,14 @@ thumbnail: /blog/assets/aya-vision/thumbnail.png
 authors:
 - user: saurabhdash
   guest: true
-  org: CohereForAI
 - user: olivernan
   guest: true
-  org: CohereForAI
 - user: ArashAhmadian
   guest: true
-  org: CohereForAI
 - user: johndang-cohere
   guest: true
-  org: CohereForAI
+orgs:
+- CohereLabs
 ---
 
 # A Deepdive into Aya Vision: Advancing the Frontier of Multilingual Multimodality


### PR DESCRIPTION
Testing #3060 on two posts with same-org authors (and where the author badges are currently not being shown)