### PR TITLE
Update video visualization in Smol2Operator

### DIFF
--- a/smol2operator.md
+++ b/smol2operator.md
@@ -15,16 +15,20 @@ authors:
 
 ---
 
-<figure style="text-align: center;">
-  <iframe width="560" height="315"
-    src="https://www.youtube.com/embed/Rv1q3OA33eM?si=-LRkSgm5obYl798S"
-    title="YouTube video player" frameborder="0"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowfullscreen>
-  </iframe>
-  <figcaption style="font-size:14px; color:#555; margin-top:8px;">
-    This video demonstrates the model obtained through the recipe described below, executing a task end-to-end.
-  </figcaption>
+<figure style="text-align: center; margin: auto;">
+  <div style="aspect-ratio: 16/9;">
+    <iframe
+      src="https://www.youtube.com/embed/Rv1q3OA33eM?si=-LRkSgm5obYl798S"
+      title="YouTube video player"
+      frameborder="0"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowfullscreen
+      style="width: 100%; height: 100%;">
+    </iframe>
+  </div>
+  <figcaption style="font-size:14px; color:#555; margin-top:8px;">
+    This video demonstrates the model obtained through the recipe described below, executing a task end-to-end.
+  </figcaption>
 </figure>
 
 ---


### PR DESCRIPTION
@A-Mahla @merveenoyan @pcuenca

With the update:

<img width="859" height="722" alt="Screenshot 2025-09-23 at 16 12 46" src="https://github.com/user-attachments/assets/abacd6b1-d681-4836-9a83-2cbfe703a16f" />

Without:

<img width="871" height="716" alt="Screenshot 2025-09-23 at 16 13 12" src="https://github.com/user-attachments/assets/59de4355-d1b2-40ad-a2ab-1a7e74b9c10e" />
