### PR TITLE
Update intel-qwen3-agent.md

### DIFF
--- a/intel-qwen3-agent.md
+++ b/intel-qwen3-agent.md
@@ -51,7 +51,7 @@ device = "GPU"
 model = LLMPipeline(target_path, device, draft_model=draft_model(draft_path, device))
 
 streamer = lambda x: print(x, end="", flush=True)
-model.generate("What is speculative decoding and how does it improve inference speed?", max_new_tokens=100, reamer=streamer)
+model.generate("What is speculative decoding and how does it improve inference speed?", max_new_tokens=100, streamer=streamer)
 ```
 
 > [!NOTE]  


### PR DESCRIPTION
Fix typo in Qwen3-8B speculative decoding example where the streamer parameter was incorrectly spelled as 'reamer'.
