### PR TITLE
Fix author name casing for VirusTotal collaboration blog post

### DIFF
--- a/_blog.yml
+++ b/_blog.yml
@@ -6846,7 +6846,7 @@
 
 - local: virustotal
   title: "Hugging Face and VirusTotal collaborate to strengthen AI security"
-  author: xcid
+  author: XciD
   thumbnail: /blog/assets/virustotal/thumbnail.png
   date: October 22, 2025
   tags:

--- a/virustotal.md
+++ b/virustotal.md
@@ -2,7 +2,7 @@
 title: "Hugging Face and VirusTotal collaborate to strengthen AI security"
 thumbnail: /blog/assets/virustotal/thumbnail.png
 authors:
-- user: xcid
+- user: XciD
 - user: bquintero
   guest: true
   org: VirusTotal


### PR DESCRIPTION
Fix author name casing for VirusTotal collaboration blog post

Problem: author `xcid` is not shown as author because of case-sensetivity

<img width="1684" height="310" alt="image" src="https://github.com/user-attachments/assets/161567ae-9307-4b9b-a1d6-05b6febe88c6" />
