### PR TITLE
replace trackio embed and fix notes section

### DIFF
--- a/hf-skills-training.md
+++ b/hf-skills-training.md
@@ -178,7 +178,8 @@ How's my training job doing?
 
 Then the agent fetches the logs and summarizes progress.
 
-<iframe src="https://evalstate-demo-training-dashboard.hf.space?project=huggingface&runs=evalstate-1761780361&sidebar=hidden&navbar=hidden" style="width:1600px; height:500px; border:0;"></iframe>
+Click [here](https://evalstate-trackio.hf.space/?project=qwen-hyperparam-sweep&runs=bs16-lr1e-5,bs16-lr5e-5,bs16-lr1e-4,bs16-lr2e-5) for an example Trackio dashboard with some completed runs.
+
 
 ### Use Your Model
 


### PR DESCRIPTION
- Replace trackio embedded iframe with link to example data (sweep test bs16) less heavy page loading, remove iframe formatting issues.
- fix [NOTE] formatting for MCP Servers - show Claude Code example with skills bouquet (ensures jobs active)
 