### PR TITLE
nits on skills post

### DIFF
--- a/hf-skills-training.md
+++ b/hf-skills-training.md
@@ -39,15 +39,15 @@ This isn't a toy demo. The skill supports the same training methods used in prod
 
 Before starting, you'll need:
 
-- A Hugging Face account with a [Pro](https://hf.co/pro) or [Team](https://hf.co/enterprise) plan (Jobs require a paid plan)
+- A Hugging Face account with a [Pro](https://hf.co/pro) or [Team / Enterprise](https://hf.co/enterprise) plan (Jobs require a paid plan)
 - A write-access token from [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens)
 - A coding agent like Claude Code, OpenAI Codex, or Google's Gemini CLI
 
-Hugging Face skills are compatible with Claude Code, Codex, and Gemini CLI. With integrations Cursor, Windsurf, and Continue, on the way.
+Hugging Face skills are compatible with Claude Code, Codex, and Gemini CLI. With integrations on the way for Cursor, Windsurf, and Continue.
 
 ### Claude Code
 
-1. Register the repository as a plugin marketplace:  
+1. Register the repository as a marketplace plugin:
    
 ```
 /plugin marketplace add huggingface/skills
@@ -95,7 +95,7 @@ gemini extensions install https://github.com/huggingface/skills.git --consent
 
 ### Connect to Hugging Face
 
-You will to authenticate you Hugging Face account with a [write-access token](https://huggingface.co/settings/tokens) so that the job can create a model repo. 
+You have to authenticate to your Hugging Face account with a [write-access token](https://huggingface.co/settings/tokens) so that the job can create a model repo. 
 
 Set up your token:
 
@@ -359,7 +359,7 @@ Some things to try:
 - Train a reasoning model with GRPO on math or code
 - Convert a model to GGUF and run it with Ollama
 
-The skill is open source. You can extend it, customize it for your workflows, or use it as a starting point for other training scenarios.
+The [skill is open source](https://hf-learn.short.gy/gh-hf-skills). You can extend it, customize it for your workflows, or use it as a starting point for other training scenarios.
 
 ---
 


### PR DESCRIPTION
In addition to these minor nits, I found some inconsistency with the supported model sizes. It says [here](https://github.com/huggingface/blog/blob/92fc1c627876e748f6e29cdfa3935815d708e342/hf-skills-training.md?plain=1#L36) that we support up to 70B params, then we say it's [7B here](https://github.com/huggingface/blog/blob/92fc1c627876e748f6e29cdfa3935815d708e342/hf-skills-training.md?plain=1#L252), and the [table we show in the post](https://github.com/huggingface/blog/blob/main/hf-skills-training.md?plain=1#L246-L252) does not match the one [from the skill itself](https://github.com/huggingface/skills/blob/main/hf-llm-trainer/skills/model-trainer/SKILL.md#hardware-selection).
