### PR TITLE
Tokenizer v5: Fix apply chat template + typo 

### DIFF
--- a/tokenizers.md
+++ b/tokenizers.md
@@ -200,7 +200,7 @@ print(text)
 model_inputs = tokenizer([text], add_special_tokens=False, return_tensors="pt")
 ```
 
-Notice how the special tokens like `<|im_start>` and `<|im_end>` are applied to the prompt before tokenizing. This is useful for the model to learn where a new sequence starts and ends.
+Notice how the special tokens like `<|im_start|>` and `<|im_end|>` are applied to the prompt before tokenizing. This is useful for the model to learn where a new sequence starts and ends.
 
 The `transformers` tokenizer adds everything the raw library lacks:
 


### PR DESCRIPTION
Avoid a common mistake, see 

https://huggingface.co/blog/qgallouedec/gotchas-in-tokenizer-behavior#7-chat-template-and-tokenization-dont-compose-due-to-special-tokens