### PR TITLE
feat: sync blog to HF bucket on push to main

### DIFF
--- a/.github/workflows/sync-to-bucket.yml
+++ b/.github/workflows/sync-to-bucket.yml
@@ -24,8 +24,11 @@ jobs:
         run: sleep 35
 
       - name: Notify hub to refresh blog metadata
+        env:
+          HUB_WEBHOOK_SECRET: ${{ secrets.HUB_BLOG_WEBHOOK_SECRET }}
         run: |
           curl -sS -X POST https://huggingface.co/api/webhooks/blog \
             -H "X-GitHub-Event: push" \
+            -H "X-Webhook-Secret: $HUB_WEBHOOK_SECRET" \
             -H "Content-Type: application/json" \
             -d '{"ref":"refs/heads/main","repository":{"html_url":"https://github.com/huggingface/blog"}}'

--- a/.github/workflows/sync-to-bucket.yml
+++ b/.github/workflows/sync-to-bucket.yml
@@ -15,5 +15,5 @@ jobs:
 
       - name: Sync to bucket
         env:
-          HF_TOKEN: ${{ secrets.HF_DOC_BUILD_PUSH }}
+          HF_TOKEN: ${{ secrets.HF_BLOG_PUSH }}
         run: hf sync . hf://buckets/hf-doc-build/blog --exclude=".git/**"

--- a/.github/workflows/sync-to-bucket.yml
+++ b/.github/workflows/sync-to-bucket.yml
@@ -17,3 +17,15 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_BLOG_PUSH }}
         run: hf sync . hf://buckets/hf-doc-build/blog --exclude=".git/**"
+
+      # Wait for the hub FUSE mount to pick up the new data (poll interval ~30s) before
+      # notifying the hub to refresh its blog metadata in the DB.
+      - name: Wait for FUSE mount to refresh
+        run: sleep 35
+
+      - name: Notify hub to refresh blog metadata
+        run: |
+          curl -sS -X POST https://huggingface.co/api/webhooks/blog \
+            -H "X-GitHub-Event: push" \
+            -H "Content-Type: application/json" \
+            -d '{"ref":"refs/heads/main","repository":{"html_url":"https://github.com/huggingface/blog"}}'

--- a/.github/workflows/sync-to-bucket.yml
+++ b/.github/workflows/sync-to-bucket.yml
@@ -28,7 +28,4 @@ jobs:
           HUB_WEBHOOK_SECRET: ${{ secrets.HUB_BLOG_WEBHOOK_SECRET }}
         run: |
           curl -sS -X POST https://huggingface.co/api/webhooks/blog \
-            -H "X-GitHub-Event: push" \
-            -H "X-Webhook-Secret: $HUB_WEBHOOK_SECRET" \
-            -H "Content-Type: application/json" \
-            -d '{"ref":"refs/heads/main","repository":{"html_url":"https://github.com/huggingface/blog"}}'
+            -H "X-Webhook-Secret: $HUB_WEBHOOK_SECRET"

--- a/.github/workflows/sync-to-bucket.yml
+++ b/.github/workflows/sync-to-bucket.yml
@@ -15,5 +15,5 @@ jobs:
 
       - name: Sync to bucket
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_TOKEN: ${{ secrets.HF_DOC_BUILD_PUSH }}
         run: hf sync . hf://buckets/hf-doc-build/blog --exclude=".git/**"

--- a/.github/workflows/sync-to-bucket.yml
+++ b/.github/workflows/sync-to-bucket.yml
@@ -1,0 +1,19 @@
+name: Sync blog to bucket
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  sync:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install huggingface_hub
+        run: pip install -U huggingface_hub
+
+      - name: Sync to bucket
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: hf sync . hf://buckets/hf-doc-build/blog --exclude=".git/**"


### PR DESCRIPTION
Add a GitHub Action that syncs the blog repo to the HF bucket `hf-doc-build/blog` on every push to main.

After the sync, the workflow waits for the hub FUSE mount to poll (~30s) and then notifies the hub via `/api/webhooks/blog` to refresh the blog metadata in MongoDB (`updateCanonicalBlogData`). This avoids the race where the hub would read stale data if notified immediately on push.

Used in combination with the upcoming moon-landing change that splits blog-and-doc into two separate bucket-backed deployments.
