### PR TITLE
Refresh Reachy Mini blog post

### DIFF
--- a/local-reachy-mini-conversation.md
+++ b/local-reachy-mini-conversation.md
@@ -300,3 +300,4 @@ You now have a fully local voice loop:
 - and answering with **Qwen3-TTS**.
 
 Star [`huggingface/speech-to-speech`](https://github.com/huggingface/speech-to-speech) and [`pollen-robotics/reachy_mini_conversation_app`](https://github.com/pollen-robotics/reachy_mini_conversation_app), and come tell us in the discussions which open-source cascade you ended up running on your robot.
+<!-- publication refresh -->


### PR DESCRIPTION
## Summary

Adds a one-line invisible HTML comment to `local-reachy-mini-conversation.md` to refresh the blog post after the previous publish issue.

## Validation

- Confirmed the diff is a single comment line
- Parsed the article front matter with Ruby YAML