### PR TITLE
Mention Parakeet version in Reachy Mini post

### DIFF
--- a/local-reachy-mini-conversation.md
+++ b/local-reachy-mini-conversation.md
@@ -17,7 +17,7 @@ Cascades are the most flexible option in the open-source landscape today, and wi
 > **TL;DR**
 > - Deploy a local speech backend for your Reachy Mini.
 > - We use our `speech-to-speech` library, a cascade approach.
-> - Recommended: **llama.cpp** with **Gemma 4**, **Silero VAD**, **Parakeet-TDT STT**, **Qwen3-TTS**.
+> - Recommended: **llama.cpp** with **Gemma 4**, **Silero VAD**, **Parakeet-TDT 0.6B v3 STT**, **Qwen3-TTS**.
 
 ---
 
@@ -63,7 +63,7 @@ Then, while we are serving the LLM in another terminal, we can simply run:
 speech-to-speech --responses_api_base_url "http://127.0.0.1:8080" --responses_api_api_key "" --mode local
 ```
 
-And you can start talking to the model through your terminal! The first time it will need to download Parakeet and Qwen3TTS, but subsequent launches are fast.
+And you can start talking to the model through your terminal! The first time it will need to download Parakeet-TDT 0.6B v3 and Qwen3TTS, but subsequent launches are fast.
 
 Here's a video showing the local conversation mode: 
 
@@ -295,7 +295,7 @@ You want the `192.168.x.x` or `10.x.x.x` one. If you see `169.254.x.x`, you're n
 You now have a fully local voice loop:
 
 - A robot listening with **Silero**,
-- transcribing with **Parakeet-TDT**,
+- transcribing with **Parakeet-TDT 0.6B v3**,
 - thinking with whichever LLM you picked, whether that's local MLX, local Transformers, a vLLM or llama.cpp server next door, or a hosted Responses API endpoint,
 - and answering with **Qwen3-TTS**.
 

--- a/local-reachy-mini-conversation.md
+++ b/local-reachy-mini-conversation.md
@@ -103,7 +103,7 @@ A cascaded voice pipeline has four stages: VAD, STT, LLM, and TTS. For three of 
 | Stage | Choice | Why |
 |-------|--------|-----|
 | VAD | **Silero VAD v5** | Tiny, accurate, runs on CPU. The de-facto default in the open-source voice-agent world. |
-| STT | **Parakeet-TDT** | Streaming-friendly, very fast, great quality on English. |
+| STT | **Parakeet-TDT 0.6B v3** | Streaming-friendly, very fast, great quality on English. |
 | TTS | **Qwen3-TTS** | Expressive, low-latency, multilingual, supports custom voices. |
 
 We are opinionated about these choices, feel free to swap them out for your own if you have a preference.


### PR DESCRIPTION
## Summary

Updates the Reachy Mini local conversation blog post to name the STT default as `Parakeet-TDT 0.6B v3`.

## Context

This matches the current `speech-to-speech` Parakeet TDT defaults:

- `mlx-community/parakeet-tdt-0.6b-v3` on Apple Silicon/MPS
- `nvidia/parakeet-tdt-0.6b-v3` on CUDA/CPU

## Validation

- Confirmed the diff is a one-line article text update
- Parsed the article front matter with Ruby YAML
- Checked that the article contains `Parakeet-TDT 0.6B v3`