### PR TITLE
Fix llama.cpp example model_name mismatch

### DIFF
--- a/local-reachy-mini-conversation.md
+++ b/local-reachy-mini-conversation.md
@@ -135,7 +135,7 @@ speech-to-speech \
   --stt parakeet-tdt \
   --tts qwen3 \
   --llm_backend responses-api \
-  --model_name "unsloth/Qwen3-4B-Instruct-2507-GGUF" \
+  --model_name "ggml-org/gemma-4-E4B-it-GGUF" \
   --responses_api_base_url "http://127.0.0.1:8080/v1"
 ```
 


### PR DESCRIPTION
## What
- Fixes the model mismatch in the llama.cpp + speech-to-speech example.
- Updates Terminal 2 model_name to match the model served in Terminal 1.

## Why
The section served ggml-org/gemma-4-E4B-it-GGUF in Terminal 1 but used a Qwen model in Terminal 2, which was a typo/copy-paste inconsistency.

Fixes #3398