### PR TITLE
Remove skypilot-org affiliation from njha author entry

### DIFF
--- a/skypilot-hf-storage.md
+++ b/skypilot-hf-storage.md
@@ -94,7 +94,7 @@ run: |
 
 What we measured:
 
-- **The model loaded free on every cloud.** Lazy reads pull only what `from_pretrained` touches, so it was ready to train in about 30 seconds (up to ~500 MB/s). Because Hugging Face charges no egress, that pull cost nothing; had the model lived in S3, every read to a GPU on another cloud would have been billed egress (~$0.09/GB on AWS).
+- **The model loaded free on every cloud.** Lazy reads pull only what `from_pretrained` touches, so it was ready to train in about 30 seconds (up to \~500 MB/s). Because Hugging Face charges no egress, that pull cost nothing; had the model lived in S3, every read to a GPU on another cloud would have been billed egress (\~$0.09/GB on AWS).
 - **Checkpoints streamed straight to the bucket** at up to ~170 MB/s (8.43 GB of weights each) and persisted past the GPU instance.
 
 Per cloud, checkpoints wrote to the bucket at:

--- a/skypilot-hf-storage.md
+++ b/skypilot-hf-storage.md
@@ -4,7 +4,6 @@ thumbnail: /blog/assets/skypilot-hf-storage/thumbnail.png
 authors:
   - user: njha
     guest: true
-    org: skypilot-org
   - user: michaelvll
     guest: true
     org: skypilot-org


### PR DESCRIPTION
### Change

In [skypilot-hf-storage.md](https://github.com/huggingface/blog/blob/main/skypilot-hf-storage.md), removed `org: skypilot-org` from the `njha` author entry, since njha is not part of the skypilot-org organization. The author is retained (with `guest: true`); only the org affiliation is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)