### PR TITLE
refactor: keep disclosure and analysis in one post, reframed

### DIFF
--- a/security-incident-july-2026.md
+++ b/security-incident-july-2026.md
@@ -37,16 +37,10 @@ We are grateful to the teams across Hugging Face who responded around the clock,
 
 The attack was initially surfaced through AI-assisted detection. Our anomaly-detection pipeline uses LLM-based triage over security telemetry to separate real signals from the daily noise, and it was the correlation of those signals that flagged the compromise.
 
-To understand what a swarm of tens of thousands of automated actions did, we ran LLM-driven analysis agents over the full attacker action log, comprised of more than 17,000 recorded events. This allowed us to reconstruct the timeline, extract indicators of compromise, map the credentials touched, and separate genuine impact from decoy activity. Thanks to this approach, we were able to do in hours what would usually take days, and match the adversary's speed.
-
-The choice of models we could use for this analysis was constrained in a way we did not anticipate; we describe this below.
-
-### What got in the way of AI-assisted response
-
-When we started the log analysis, we first used frontier models behind commercial APIs. This did not work: the analysis requires submitting large volumes of real attack commands, exploit payloads, and C2 artifacts, and these requests were blocked by the providers' safety guardrails, which cannot distinguish an incident responder from an attacker. We ran the forensic analysis instead on GLM 5.2, an open-weight model, on our own infrastructure. This had a second benefit: no attacker data, and none of the credentials it referenced, left our environment.
-
-This experience points to a gap worth planning for. We do not know which model powered the attacker's agents, whether a jailbroken hosted model or an unrestricted open-weight one; either way, the attacker was bound by no usage policy, while our own forensic work was blocked by the guardrails of the hosted models we first tried. The practical lesson for defenders: have a capable model you can run on your own infrastructure vetted and ready *before* an incident, both to avoid guardrail lockout and to keep attacker data and credentials from leaving your environment. This is not an argument against safety measures on hosted models, and we are sharing this feedback with the providers concerned.
+To understand what a swarm of tens of thousands of automated actions did, we ran LLM-driven analysis agents over the full attacker action log, comprised of more than 17,000 recorded events. We ran this analysis on models hosted on our own infrastructure, so that no attacker data - and none of the credentials it referenced - left our environment. This allowed us to reconstruct the timeline, extract indicators of compromise, map the credentials touched, and separate genuine impact from decoy activity, doing in hours what would usually take days.
 
 ## What this means
 
 Autonomous, AI-driven offensive tooling is no longer theoretical. It lowers the cost of running a broad, patient, multi-stage campaign, and it operates at machine speed. Defending an online platform now means treating the data and model surface as a first-class attack surface, and using AI on defense to keep pace. We will keep investing there, and keep sharing what we learn.
+
+We will publish a more detailed technical write-up of how we detected and analyzed this campaign, and what we learned using AI for incident response, in a follow-up post.

--- a/security-incident-july-2026.md
+++ b/security-incident-july-2026.md
@@ -27,6 +27,12 @@ The campaign was run by an autonomous agent framework (appearing to be built on 
 
 We are working with outside cybersecurity forensic specialists to investigate the issue and review our security policies and procedures. Finally, we have also reported this incident to law enforcement agencies.
 
+## For our community
+
+As a precaution, we recommend rotating any access tokens and reviewing recent activity on your account. If you believe you are affected, or want to report a security concern, contact us at security@huggingface.co.
+
+We are grateful to the teams across Hugging Face who responded around the clock, and we are sorry for any disruption this caused. Security is never finished; we will keep raising the bar.
+
 ## Analyzing an AI-driven intrusion
 
 The attack was initially surfaced through AI-assisted detection. Our anomaly-detection pipeline uses LLM-based triage over security telemetry to separate real signals from the daily noise, and it was the correlation of those signals that flagged the compromise.
@@ -35,18 +41,12 @@ To understand what a swarm of tens of thousands of automated actions did, we ran
 
 The choice of models we could use for this analysis was constrained in a way we did not anticipate; we describe this below.
 
-### The asymmetry problem
+### What got in the way of AI-assisted response
 
 When we started the log analysis, we first used frontier models behind commercial APIs. This did not work: the analysis requires submitting large volumes of real attack commands, exploit payloads, and C2 artifacts, and these requests were blocked by the providers' safety guardrails, which cannot distinguish an incident responder from an attacker. We ran the forensic analysis instead on GLM 5.2, an open-weight model, on our own infrastructure. This had a second benefit: no attacker data, and none of the credentials it referenced, left our environment.
 
-This experience points to an asymmetry. The attacker assembled its offensive system from openly available components and was bound by no usage policy. Defenders who rely on hosted frontier models are subject to guardrails that can make those models unusable precisely when they are needed. In our case, an open-weight model was a necessary part of the response. This is not an argument against safety measures on hosted models; it is a reason to treat capable open models as part of the security equation.
+This experience points to a gap worth planning for. We do not know which model powered the attacker's agents, whether a jailbroken hosted model or an unrestricted open-weight one; either way, the attacker was bound by no usage policy, while our own forensic work was blocked by the guardrails of the hosted models we first tried. The practical lesson for defenders: have a capable model you can run on your own infrastructure vetted and ready *before* an incident, both to avoid guardrail lockout and to keep attacker data and credentials from leaving your environment. This is not an argument against safety measures on hosted models, and we are sharing this feedback with the providers concerned.
 
 ## What this means
 
 Autonomous, AI-driven offensive tooling is no longer theoretical. It lowers the cost of running a broad, patient, multi-stage campaign, and it operates at machine speed. Defending an online platform now means treating the data and model surface as a first-class attack surface, and using AI on defense to keep pace. We will keep investing there, and keep sharing what we learn.
-
-## For our community
-
-As a precaution, we recommend rotating any access tokens and reviewing recent activity on your account. If you believe you are affected, or want to report a security concern, contact us at security@huggingface.co.
-
-We are grateful to the teams across Hugging Face who responded around the clock, and we are sorry for any disruption this caused. Security is never finished; we will keep raising the bar.

--- a/security-incident-july-2026.md
+++ b/security-incident-july-2026.md
@@ -41,7 +41,7 @@ To understand what a swarm of tens of thousands of automated actions did, we ran
 
 The choice of models we could use for this analysis was constrained in a way we did not anticipate; we describe this below.
 
-### What got in the way of AI-assisted response
+### The asymmetry problem
 
 When we started the log analysis, we first used frontier models behind commercial APIs. This did not work: the analysis requires submitting large volumes of real attack commands, exploit payloads, and C2 artifacts, and these requests were blocked by the providers' safety guardrails, which cannot distinguish an incident responder from an attacker. We ran the forensic analysis instead on GLM 5.2, an open-weight model, on our own infrastructure. This had a second benefit: no attacker data, and none of the credentials it referenced, left our environment.
 

--- a/security-incident-july-2026.md
+++ b/security-incident-july-2026.md
@@ -37,10 +37,16 @@ We are grateful to the teams across Hugging Face who responded around the clock,
 
 The attack was initially surfaced through AI-assisted detection. Our anomaly-detection pipeline uses LLM-based triage over security telemetry to separate real signals from the daily noise, and it was the correlation of those signals that flagged the compromise.
 
-To understand what a swarm of tens of thousands of automated actions did, we ran LLM-driven analysis agents over the full attacker action log, comprised of more than 17,000 recorded events. We ran this analysis on models hosted on our own infrastructure, so that no attacker data - and none of the credentials it referenced - left our environment. This allowed us to reconstruct the timeline, extract indicators of compromise, map the credentials touched, and separate genuine impact from decoy activity, doing in hours what would usually take days.
+To understand what a swarm of tens of thousands of automated actions did, we ran LLM-driven analysis agents over the full attacker action log, comprised of more than 17,000 recorded events. This allowed us to reconstruct the timeline, extract indicators of compromise, map the credentials touched, and separate genuine impact from decoy activity. Thanks to this approach, we were able to do in hours what would usually take days, and match the adversary's speed.
+
+The choice of models we could use for this analysis was constrained in a way we did not anticipate; we describe this below.
+
+### What got in the way of AI-assisted response
+
+When we started the log analysis, we first used frontier models behind commercial APIs. This did not work: the analysis requires submitting large volumes of real attack commands, exploit payloads, and C2 artifacts, and these requests were blocked by the providers' safety guardrails, which cannot distinguish an incident responder from an attacker. We ran the forensic analysis instead on GLM 5.2, an open-weight model, on our own infrastructure. This had a second benefit: no attacker data, and none of the credentials it referenced, left our environment.
+
+This experience points to a gap worth planning for. We do not know which model powered the attacker's agents, whether a jailbroken hosted model or an unrestricted open-weight one; either way, the attacker was bound by no usage policy, while our own forensic work was blocked by the guardrails of the hosted models we first tried. The practical lesson for defenders: have a capable model you can run on your own infrastructure vetted and ready *before* an incident, both to avoid guardrail lockout and to keep attacker data and credentials from leaving your environment. This is not an argument against safety measures on hosted models, and we are sharing this feedback with the providers concerned.
 
 ## What this means
 
 Autonomous, AI-driven offensive tooling is no longer theoretical. It lowers the cost of running a broad, patient, multi-stage campaign, and it operates at machine speed. Defending an online platform now means treating the data and model surface as a first-class attack surface, and using AI on defense to keep pace. We will keep investing there, and keep sharing what we learn.
-
-We will publish a more detailed technical write-up of how we detected and analyzed this campaign, and what we learned using AI for incident response, in a follow-up post.


### PR DESCRIPTION
Proposal for the discussion in #3465, incorporating the feedback from the Slack thread. Keeps everything in a single post, no content removed.

1. **Section order**: client-facing content first. "For our community" (token rotation, contact) moves up right after "What we did". The technical analysis ("Analyzing an AI-driven intrusion") and "What this means" close the post. Customers get impact and actions without reading through the analysis; technical readers reach it naturally.
2. **"The asymmetry problem" conclusion reframed as a lesson for defenders**: the closing paragraph no longer makes an industry-level claim ("treat capable open models as part of the security equation"). It states the facts (we don't know which model the attacker used, whether a jailbroken hosted model or an unrestricted open-weight one, and the asymmetry holds either way), turns the takeaway into actionable incident-response preparedness advice, and mentions we are sharing the feedback with the providers concerned.