### PR TITLE
fix: fail sync workflow when blog webhook call fails

### DIFF
--- a/.github/workflows/sync-to-bucket.yml
+++ b/.github/workflows/sync-to-bucket.yml
@@ -27,5 +27,5 @@ jobs:
         env:
           HUB_WEBHOOK_SECRET: ${{ secrets.HUB_BLOG_WEBHOOK_SECRET }}
         run: |
-          curl -sS -X POST https://huggingface.co/api/webhooks/blog \
+          curl -sSf -X POST https://huggingface.co/api/webhooks/blog \
             -H "X-Webhook-Secret: $HUB_WEBHOOK_SECRET"


### PR DESCRIPTION
The "Notify hub to refresh blog metadata" step uses `curl -sS` without `--fail`, so an HTTP error from the webhook endpoint leaves the step green. This bit us today: the hub-side webhook secret was rotated (post-incident secret rotation) without updating the `HUB_BLOG_WEBHOOK_SECRET` repo secret, the webhook returned `{"error":"Invalid username or password."}`, the workflow stayed green, and the security incident disclosure post silently never went live until the secret was re-synced and the run re-triggered.

With `-f`, curl exits non-zero on HTTP >= 400 and the workflow fails visibly.