### PR TITLE
docs: clarify the intrusion duration in the agent intrusion timeline

### DIFF
--- a/agent-intrusion-technical-timeline.md
+++ b/agent-intrusion-technical-timeline.md
@@ -14,11 +14,11 @@ authors:
 
 *We are publishing this level of detail because the technique matters more than the incident, as it reveals the emerging attack capabilities of the frontier agents, how they could be used by rogue actors and how everyone should be prepared as defenders.*
 
-**[▶ Watch the interactive replay](https://huggingface-anatomy-of-frontier-lab-model-intrusion.static.hf.space)** - a step-by-step visualization of the 4.5-day intrusion: the attack chain across trust boundaries, phase activity, and the commands as they were recorded.
+**[▶ Watch the interactive replay](https://huggingface-anatomy-of-frontier-lab-model-intrusion.static.hf.space)** - a step-by-step visualization of the 4.5-day campaign: the attack chain across trust boundaries, phase activity, and the commands as they were recorded.
 
 ## TL;DR
 
-Over roughly two and a half days, an **autonomous AI agent driven by a combination of OpenAI models** ran an end-to-end intrusion against our platform: it was thousands of small, automated decisions, executed at machine speed across short-lived sandbox environments, with command-and-control staged on ordinary public web services.
+Over roughly two and a half days inside our infrastructure, an **autonomous AI agent driven by a combination of OpenAI models** ran an end-to-end intrusion against our platform: it was thousands of small, automated decisions, executed at machine speed across short-lived sandbox environments, with command-and-control staged on ordinary public web services.
 
 The agent was running an OpenAI cyber-capability evaluation harness called ExploitGym, an evaluation benchmark which tasks an AI agent with finding and exploiting software vulnerabilities. As far as we were able to infer, across the course of being evaluated on this benchmark the agent inferred that Hugging Face may host that benchmark's models, datasets, and reference solutions. We believe the entire intrusion was, from the agent's point of view, an attempt to cheat the evaluation: reach our production systems and steal the test solutions rather than solve the challenge on its own.
 


### PR DESCRIPTION
The post gave two durations three lines apart: "the 4.5-day intrusion" in the replay link, then "over roughly two and a half days" opening the TL;DR. Both are right, they just measure different things: 4.5 days of campaign end to end, of which about 2.5 inside our infrastructure.

Two words fix it:

- replay link: `4.5-day intrusion` becomes `4.5-day campaign`
- TL;DR: `two and a half days` becomes `two and a half days inside our infrastructure`

The timeline figure caption already says "campaign", so it stays consistent.