### PR TITLE
Responsive height for the intrusion replay embed

### DIFF
--- a/agent-intrusion-technical-timeline.md
+++ b/agent-intrusion-technical-timeline.md
@@ -16,7 +16,9 @@ authors:
 
 Below is an interactive replay of the intrusion - a step-by-step visualization of the 4.5-day campaign: the attack chain across trust boundaries, phase activity, and the commands as they were recorded.
 
-<iframe src="https://huggingface-anatomy-of-frontier-lab-model-intrusion.static.hf.space/index.html#embed" width="100%" height="1420px" frameborder="0" title="Interactive replay of the July 2026 agent intrusion"></iframe>
+<div style="width:100%; height:clamp(1600px, min(calc(3080px - 94vw), calc(57269px - 8950vw)), 2800px); border-radius:12px; overflow:hidden;">
+  <iframe src="https://huggingface-anatomy-of-frontier-lab-model-intrusion.static.hf.space/index.html#embed" width="100%" height="100%" frameborder="0"></iframe>
+</div>
 
 **[⛶ Watch the interactive replay in full screen](https://huggingface-anatomy-of-frontier-lab-model-intrusion.static.hf.space)**
 

--- a/agent-intrusion-technical-timeline.md
+++ b/agent-intrusion-technical-timeline.md
@@ -16,7 +16,7 @@ authors:
 
 Below is an interactive replay of the intrusion - a step-by-step visualization of the 4.5-day campaign: the attack chain across trust boundaries, phase activity, and the commands as they were recorded.
 
-<div style="width:100%; height:clamp(1600px, min(calc(3080px - 94vw), calc(57269px - 8950vw)), 2800px); border-radius:12px; overflow:hidden;">
+<div style="width:100%; height:clamp(1600px, min(calc(3080px - 94vw), calc(68800px - 10500vw)), 2800px); border-radius:12px; overflow:hidden;">
   <iframe src="https://huggingface-anatomy-of-frontier-lab-model-intrusion.static.hf.space/index.html#embed" width="100%" height="100%" frameborder="0"></iframe>
 </div>
 

--- a/agent-intrusion-technical-timeline.md
+++ b/agent-intrusion-technical-timeline.md
@@ -16,7 +16,7 @@ authors:
 
 Below is an interactive replay of the intrusion - a step-by-step visualization of the 4.5-day campaign: the attack chain across trust boundaries, phase activity, and the commands as they were recorded.
 
-<div style="width:100%; height:clamp(1600px, min(calc(3080px - 94vw), calc(68800px - 10500vw)), 2800px); border-radius:12px; overflow:hidden;">
+<div style="width:100%; height:clamp(1480px, max(min(calc(3080px - 94vw), calc(68800px - 10500vw)), calc(1651px - 8vw)), 2800px); border-radius:12px; overflow:hidden;">
   <iframe src="https://huggingface-anatomy-of-frontier-lab-model-intrusion.static.hf.space/index.html#embed" width="100%" height="100%" frameborder="0"></iframe>
 </div>
 


### PR DESCRIPTION
Wraps the replay iframe in a div whose inline `clamp()` height tracks the measured embed height at every blog column width (832/704/736/608/vw-32), so the iframe no longer inner-scrolls on narrow screens. Pairs with https://huggingface.co/spaces/huggingface/anatomy-of-frontier-lab-model-intrusion/discussions/3 (embed padding + two-column held to 601px), which should merge first.