### PR TITLE
Update TRL example paths after examples/ reorg

### DIFF
--- a/dpo_vlm.md
+++ b/dpo_vlm.md
@@ -354,10 +354,10 @@ Try it yourself and see how the model performs on your own examples!
 
 ## Finetuning Llava 1.5, PaliGemma and others
 
-At the time of writing, the DPO implementation in TRL supports Idefics2, Llava 1.5, and PaliGemma, with ongoing efforts to add support for more models. The easiest way to fine-tune these models is to use the [example script](https://github.com/huggingface/trl/blob/main/examples/dpo_reduce_hallucinations/dpo_vlm.py) provided in the TRL repository. For example, to finetune PaliGemma, you can use the following command:
+At the time of writing, the DPO implementation in TRL supports Idefics2, Llava 1.5, and PaliGemma, with ongoing efforts to add support for more models. The easiest way to fine-tune these models is to use the [example script](https://github.com/huggingface/trl/blob/main/examples/dpo_reduce_hallucinations/dpo_reduce_hallucinations.py) provided in the TRL repository. For example, to finetune PaliGemma, you can use the following command:
 
 ```sh
-accelerate launch examples/dpo_reduce_hallucinations/dpo_vlm.py \
+accelerate launch examples/dpo_reduce_hallucinations/dpo_reduce_hallucinations.py \
     --dataset_name HuggingFaceH4/rlaif-v_formatted \
     --model_name_or_path google/paligemma-3b-pt-224 \
     --per_device_train_batch_size 2 \

--- a/dpo_vlm.md
+++ b/dpo_vlm.md
@@ -354,10 +354,10 @@ Try it yourself and see how the model performs on your own examples!
 
 ## Finetuning Llava 1.5, PaliGemma and others
 
-At the time of writing, the DPO implementation in TRL supports Idefics2, Llava 1.5, and PaliGemma, with ongoing efforts to add support for more models. The easiest way to fine-tune these models is to use the [example script](https://github.com/huggingface/trl/blob/main/examples/scripts/dpo_vlm.py) provided in the TRL repository. For example, to finetune PaliGemma, you can use the following command:
+At the time of writing, the DPO implementation in TRL supports Idefics2, Llava 1.5, and PaliGemma, with ongoing efforts to add support for more models. The easiest way to fine-tune these models is to use the [example script](https://github.com/huggingface/trl/blob/main/examples/dpo_reduce_hallucinations/dpo_vlm.py) provided in the TRL repository. For example, to finetune PaliGemma, you can use the following command:
 
 ```sh
-accelerate launch examples/scripts/dpo_visual.py \
+accelerate launch examples/dpo_reduce_hallucinations/dpo_vlm.py \
     --dataset_name HuggingFaceH4/rlaif-v_formatted \
     --model_name_or_path google/paligemma-3b-pt-224 \
     --per_device_train_batch_size 2 \

--- a/gemma.md
+++ b/gemma.md
@@ -247,7 +247,7 @@ Training LLMs can be technically and computationally challenging. In this sectio
 
 An example command to fine-tune Gemma on OpenAssistant’s [chat dataset](https://huggingface.co/datasets/OpenAssistant/oasst_top1_2023-08-25) can be found below. We use 4-bit quantization and [QLoRA](https://arxiv.org/abs/2305.14314) to conserve memory to target all the attention blocks' linear layers.
 
-First, install the nightly version of 🤗 TRL and clone the repo to access the [training script](https://github.com/huggingface/trl/blob/main/examples/scripts/sft.py):
+First, install the nightly version of 🤗 TRL and clone the repo to access the [training script](https://github.com/huggingface/trl/blob/main/trl/scripts/sft.py):
 
 ```jsx
 pip install -U transformers trl peft bitsandbytes
@@ -259,7 +259,7 @@ Then you can run the script:
 
 ```jsx
 accelerate launch --config_file examples/accelerate_configs/multi_gpu.yaml --num_processes=1 \
-	examples/scripts/sft.py \
+	trl/scripts/sft.py \
 	--model_name google/gemma-7b \
 	--dataset_name OpenAssistant/oasst_top1_2023-08-25 \
 	--per_device_train_batch_size 2 \

--- a/gemma2.md
+++ b/gemma2.md
@@ -220,7 +220,7 @@ Training LLMs can be technically and computationally challenging. In this sectio
 
 An example command to fine-tune Gemma on OpenAssistant’s [chat dataset](https://huggingface.co/datasets/OpenAssistant/oasst_top1_2023-08-25) can be found below. We use 4-bit quantization and [QLoRA](https://arxiv.org/abs/2305.14314) to conserve memory to target all the attention blocks' linear layers. Note that, unlike dense transformers, one should not target the MLP layers as they are sparse and don’t interact well with PEFT.
 
-First, install the nightly version of 🤗 TRL and clone the repo to access the [training script](https://github.com/huggingface/trl/blob/main/examples/scripts/sft.py):
+First, install the nightly version of 🤗 TRL and clone the repo to access the [training script](https://github.com/huggingface/trl/blob/main/trl/scripts/sft.py):
 
 ```jsx
 pip install "transformers>=4.42.3" --upgrade
@@ -236,7 +236,7 @@ Then you can run the script:
 ```bash
 # peft tuning; single GPU; https://wandb.ai/costa-huang/huggingface/runs/l1l53cst
 python \
-	examples/scripts/sft.py \
+	trl/scripts/sft.py \
 	--model_name google/gemma-2-27b \
 	--dataset_name OpenAssistant/oasst_top1_2023-08-25 \
 	--dataset_text_field="text" \
@@ -267,7 +267,7 @@ If you have more GPUs to spare, you can run training with DeepSpeed and ZeRO Sta
 
 ```bash
 accelerate launch --config_file=examples/accelerate_configs/deepspeed_zero3.yaml \
-	examples/scripts/sft.py \
+	trl/scripts/sft.py \
 	--model_name google/gemma-2-27b \
 	--dataset_name OpenAssistant/oasst_top1_2023-08-25 \
 	--dataset_text_field="text" \

--- a/gemma4.md
+++ b/gemma4.md
@@ -722,7 +722,7 @@ Get started:
 ```shell
 # pip install git+https://github.com/huggingface/trl.git
 
-python examples/scripts/openenv/carla_vlm_gemma.py \
+python examples/grpo_carla/carla_vlm_gemma.py \
 	--env-urls https://sergiopaniego-carla-env.hf.space \
 			https://sergiopaniego-carla-env-2.hf.space \
 	--model google/gemma-4-E2B-it

--- a/llama31.md
+++ b/llama31.md
@@ -811,7 +811,7 @@ In this section, we’ll look at the tools available in the Hugging Face ecosyst
 <details close>
 <summary>Fine-Tuning Example with Hugging Face TRL</summary>
 
-First, install the nightly version of 🤗 TRL and clone the repo to access the [training script](https://github.com/huggingface/trl/blob/main/examples/scripts/sft.py):
+First, install the nightly version of 🤗 TRL and clone the repo to access the [training script](https://github.com/huggingface/trl/blob/main/trl/scripts/sft.py):
 
 ``` 
 pip install "transformers>=4.43.2" --upgrade
@@ -826,7 +826,7 @@ Then you can run the script:
 
 ```
 python \
-    examples/scripts/sft.py \
+    trl/scripts/sft.py \
     --model_name meta-llama/Meta-Llama-3.1-8B \
     --dataset_name OpenAssistant/oasst_top1_2023-08-25 \
     --dataset_text_field="text" \
@@ -851,7 +851,7 @@ If you have more GPUs to spare, you can run training with DeepSpeed and ZeRO Sta
 
 ```
 accelerate launch --config_file=examples/accelerate_configs/deepspeed_zero3.yaml \
-    examples/scripts/sft.py \
+    trl/scripts/sft.py \
     --model_name meta-llama/Meta-Llama-3.1-8B \
     --dataset_name OpenAssistant/oasst_top1_2023-08-25 \
     --dataset_text_field="text" \

--- a/llama32.md
+++ b/llama32.md
@@ -476,12 +476,12 @@ trl sft  --model_name_or_path meta-llama/Llama-3.2-3B \
          --gradient_checkpointing
 ```
 
-Support for fine tuning Llama 3.2 Vision is also available in TRL with [this script](https://github.com/huggingface/trl/tree/main/examples/scripts/sft_vlm.py).
+Support for fine tuning Llama 3.2 Vision is also available in TRL with [this script](https://github.com/huggingface/trl/tree/main/examples/sft_visual_chat/sft_vlm.py).
 
 ```bash
 # Tested on 8x H100 GPUs
 accelerate launch --config_file=examples/accelerate_configs/deepspeed_zero3.yaml \
-    examples/scripts/sft_vlm.py \
+    examples/sft_visual_chat/sft_vlm.py \
     --dataset_name HuggingFaceH4/llava-instruct-mix-vsft \
     --model_name_or_path meta-llama/Llama-3.2-11B-Vision-Instruct \
     --per_device_train_batch_size 8 \

--- a/llama32.md
+++ b/llama32.md
@@ -476,12 +476,12 @@ trl sft  --model_name_or_path meta-llama/Llama-3.2-3B \
          --gradient_checkpointing
 ```
 
-Support for fine tuning Llama 3.2 Vision is also available in TRL with [this script](https://github.com/huggingface/trl/tree/main/examples/sft_visual_chat/sft_vlm.py).
+Support for fine tuning Llama 3.2 Vision is also available in TRL with [this script](https://github.com/huggingface/trl/tree/main/examples/sft_visual_chat/sft_visual_chat.py).
 
 ```bash
 # Tested on 8x H100 GPUs
 accelerate launch --config_file=examples/accelerate_configs/deepspeed_zero3.yaml \
-    examples/sft_visual_chat/sft_vlm.py \
+    examples/sft_visual_chat/sft_visual_chat.py \
     --dataset_name HuggingFaceH4/llava-instruct-mix-vsft \
     --model_name_or_path meta-llama/Llama-3.2-11B-Vision-Instruct \
     --per_device_train_batch_size 8 \

--- a/mixtral.md
+++ b/mixtral.md
@@ -188,7 +188,7 @@ Training LLMs can be technically and computationally challenging. In this sectio
 
 An example command to fine-tune Mixtral on OpenAssistant’s [chat dataset](https://huggingface.co/datasets/OpenAssistant/oasst_top1_2023-08-25) can be found below. To conserve memory, we make use of 4-bit quantization and [QLoRA](https://arxiv.org/abs/2305.14314) to target all the linear layers in the attention blocks. Note that unlike dense transformers, one should not target the MLP layers as they are sparse and don’t interact well with PEFT.
 
-First, install the nightly version of 🤗 TRL and clone the repo to access the [training script](https://github.com/huggingface/trl/blob/main/examples/scripts/sft.py):
+First, install the nightly version of 🤗 TRL and clone the repo to access the [training script](https://github.com/huggingface/trl/blob/main/trl/scripts/sft.py):
 
 ```bash
 pip install -U transformers
@@ -201,7 +201,7 @@ Then you can run the script:
 
 ```bash
 accelerate launch --config_file examples/accelerate_configs/multi_gpu.yaml --num_processes=1 \
-	examples/scripts/sft.py \
+	trl/scripts/sft.py \
 	--model_name mistralai/Mixtral-8x7B-v0.1 \
 	--dataset_name trl-lib/ultrachat_200k_chatml \
 	--batch_size 2 \

--- a/muse-glimmer.md
+++ b/muse-glimmer.md
@@ -536,7 +536,7 @@ You can use TRL to fine-tune Muse Glimmer using various methods from SFT to Asyn
 
 As part of this release, we ship an example to fine-tune [Muse Glimmer on small split of MolmoWeb dataset](https://huggingface.co/merve/smol-vision/blob/main/qlora_click_grounding.ipynb). This shows how to make model generate structured outputs and how to fine-tune on images.
 
-We also experimented with running the model on [OpenCode with AsyncGRPO example](https://github.com/huggingface/trl/blob/main/examples/async_grpo_opencode/opencode.py). Model shows strong coding capabilities, so we encourage you to try training with coding environments in OpenEnv and TRL.
+We also experimented with running the model on [OpenCode with AsyncGRPO example](https://github.com/huggingface/trl/blob/main/examples/async_grpo_opencode/async_grpo_opencode.py). Model shows strong coding capabilities, so we encourage you to try training with coding environments in OpenEnv and TRL.
 
 ## Demos
 

--- a/muse-glimmer.md
+++ b/muse-glimmer.md
@@ -536,7 +536,7 @@ You can use TRL to fine-tune Muse Glimmer using various methods from SFT to Asyn
 
 As part of this release, we ship an example to fine-tune [Muse Glimmer on small split of MolmoWeb dataset](https://huggingface.co/merve/smol-vision/blob/main/qlora_click_grounding.ipynb). This shows how to make model generate structured outputs and how to fine-tune on images.
 
-We also experimented with running the model on [OpenCode with AsyncGRPO example](https://github.com/huggingface/trl/blob/main/examples/scripts/openenv/opencode.py). Model shows strong coding capabilities, so we encourage you to try training with coding environments in OpenEnv and TRL.
+We also experimented with running the model on [OpenCode with AsyncGRPO example](https://github.com/huggingface/trl/blob/main/examples/async_grpo_opencode/opencode.py). Model shows strong coding capabilities, so we encourage you to try training with coding environments in OpenEnv and TRL.
 
 ## Demos
 

--- a/smolvlm.md
+++ b/smolvlm.md
@@ -284,7 +284,7 @@ SmolVLM also comes with TRL integration so you can apply Direct Preference Optim
 
 ``` bash
 accelerate launch \
-  --config_file examples/accelerate_configs/multi_gpu.yaml examples/dpo_reduce_hallucinations/dpo_vlm.py  \
+  --config_file examples/accelerate_configs/multi_gpu.yaml examples/dpo_reduce_hallucinations/dpo_reduce_hallucinations.py  \
   --dataset_name HuggingFaceH4/rlaif-v_formatted \
   --model_name_or_path HuggingFaceTB/SmolVLM-Instruct \
   --per_device_train_batch_size 8 \

--- a/smolvlm.md
+++ b/smolvlm.md
@@ -284,7 +284,7 @@ SmolVLM also comes with TRL integration so you can apply Direct Preference Optim
 
 ``` bash
 accelerate launch \
-  --config_file examples/accelerate_configs/multi_gpu.yaml examples/scripts/dpo_vlm.py  \
+  --config_file examples/accelerate_configs/multi_gpu.yaml examples/dpo_reduce_hallucinations/dpo_vlm.py  \
   --dataset_name HuggingFaceH4/rlaif-v_formatted \
   --model_name_or_path HuggingFaceTB/SmolVLM-Instruct \
   --per_device_train_batch_size 8 \

--- a/thinkingmachines-inkling.md
+++ b/thinkingmachines-inkling.md
@@ -460,7 +460,7 @@ uv run --env-file .env \
 
 </details>
 
-If you’re working with Transformers Reinforcement Learning we suggest using Inkling as a teacher model in a knowledge distillation setup. For example, take advantage of Inkling’s document understanding abilities to improve the performance of a smaller (on-device) model. In [this example](https://github.com/huggingface/trl/blob/main/examples/scripts/gold.py), we use the transformer reinforcement learning library and the GOLD algorithm to distill knowledge. GOLD is handy here because it matches token logits between different tokenizers, so you can distill to any model on the hub.
+If you’re working with Transformers Reinforcement Learning we suggest using Inkling as a teacher model in a knowledge distillation setup. For example, take advantage of Inkling’s document understanding abilities to improve the performance of a smaller (on-device) model. In [this example](https://github.com/huggingface/trl/blob/v1.10.0/examples/scripts/gold.py), we use the transformer reinforcement learning library and the GOLD algorithm to distill knowledge. GOLD is handy here because it matches token logits between different tokenizers, so you can distill to any model on the hub.
 
 ## Deploying Inkling and Inkling-Small 
 

--- a/thinkingmachines-inkling.md
+++ b/thinkingmachines-inkling.md
@@ -460,7 +460,7 @@ uv run --env-file .env \
 
 </details>
 
-If you’re working with Transformers Reinforcement Learning we suggest using Inkling as a teacher model in a knowledge distillation setup. For example, take advantage of Inkling’s document understanding abilities to improve the performance of a smaller (on-device) model. In [this example](https://github.com/huggingface/trl/blob/v1.10.0/examples/scripts/gold.py), we use the transformer reinforcement learning library and the GOLD algorithm to distill knowledge. GOLD is handy here because it matches token logits between different tokenizers, so you can distill to any model on the hub.
+If you’re working with Transformers Reinforcement Learning we suggest using Inkling as a teacher model in a knowledge distillation setup. For example, take advantage of Inkling’s document understanding abilities to improve the performance of a smaller (on-device) model. In [this example](https://github.com/huggingface/trl/blob/main/examples/gold_chatbot_arena/gold_chatbot_arena.py), we use the transformer reinforcement learning library and the GOLD algorithm to distill knowledge. GOLD is handy here because it matches token logits between different tokenizers, so you can distill to any model on the hub.
 
 ## Deploying Inkling and Inkling-Small 
 

--- a/trl-ddpo.md
+++ b/trl-ddpo.md
@@ -98,7 +98,7 @@ Note: you could choose to use `tensorboard` rather than `wandb` for which you’
 
 ### A Walkthrough
 
-The main classes within the `trl` library responsible for DDPO training are the `DDPOTrainer` and `DDPOConfig` classes. See [docs](https://huggingface.co/docs/trl/ddpo_trainer#getting-started-with-examplesscriptsstablediffusiontuningpy) for more general info on the `DDPOTrainer` and `DDPOConfig`. There is an [example training script](https://github.com/huggingface/trl/blob/main/examples/scripts/ddpo.py) in the `trl` repo. It uses both of these classes in tandem with default implementations of required inputs and default parameters to finetune a default pretrained Stable Diffusion Model from `RunwayML` . 
+The main classes within the `trl` library responsible for DDPO training are the `DDPOTrainer` and `DDPOConfig` classes. See [docs](https://huggingface.co/docs/trl/ddpo_trainer#getting-started-with-examplesscriptsstablediffusiontuningpy) for more general info on the `DDPOTrainer` and `DDPOConfig`. There is an [example training script](https://github.com/huggingface/trl/blob/v0.9.6/examples/scripts/ddpo.py) in the `trl` repo. It uses both of these classes in tandem with default implementations of required inputs and default parameters to finetune a default pretrained Stable Diffusion Model from `RunwayML` . 
 
 This example script uses `wandb` for logging and uses an aesthetic reward model whose weights are read from a public facing HuggingFace repo (so gathering data and training the aesthetic reward model is already done for you). The default prompt dataset used is a list of animal names.
 

--- a/trl-vlm-alignment.md
+++ b/trl-vlm-alignment.md
@@ -202,7 +202,7 @@ In addition to MPO, GRPO, and GSPO, TRL now supports [Reinforce Leave One Out](h
 
 #### Reinforce Leave One Out (RLOO)
 
-RLOO now supports common VLMs. You can find a complete training example in the [`rloo_vlm.py`](https://github.com/huggingface/trl/blob/main/examples/rloo_visual_math/rloo_vlm.py) script.
+RLOO now supports common VLMs. You can find a complete training example in the [`rloo_vlm.py`](https://github.com/huggingface/trl/blob/main/examples/rloo_visual_math/rloo_visual_math.py) script.
 
 Here’s how to set up a `RLOOTrainer`:
 
@@ -221,17 +221,17 @@ trainer.train()
 And to launch training directly from the example script:
 
 ```bash
-CUDA_VISIBLE_DEVICES=1,2 python3 examples/rloo_visual_math/rloo_vlm.py --model_name_or_path Qwen/Qwen2.5-VL-3B-Instruct
+CUDA_VISIBLE_DEVICES=1,2 python3 examples/rloo_visual_math/rloo_visual_math.py --model_name_or_path Qwen/Qwen2.5-VL-3B-Instruct
 ```
 
 #### Online Direct Preference Optimization (Online DPO)
 
-Online DPO also supports VLMs. See the [`online_dpo_vlm.py`](https://github.com/huggingface/trl/blob/main/examples/online_dpo_visual_math/online_dpo_vlm.py) script for a simple example.
+Online DPO also supports VLMs. See the [`online_dpo_vlm.py`](https://github.com/huggingface/trl/blob/main/examples/online_dpo_visual_math/online_dpo_visual_math.py) script for a simple example.
 
 To run the example script (vLLM integration will be discussed later):
 
 ```bash
-CUDA_VISIBLE_DEVICES=1,2 python3 examples/online_dpo_visual_math/online_dpo_vlm.py --model_name_or_path Qwen/Qwen2.5-VL-3B-Instruct --use_vllm --vllm_mode server
+CUDA_VISIBLE_DEVICES=1,2 python3 examples/online_dpo_visual_math/online_dpo_visual_math.py --model_name_or_path Qwen/Qwen2.5-VL-3B-Instruct --use_vllm --vllm_mode server
 ```
 
 > [!NOTE]
@@ -256,14 +256,14 @@ trainer.train()
 
 To train a VLM, you need to provide a dataset with an additional `images` column containing the images to be processed. You can take a look at [Dataset Formats — Vision Datasets](https://huggingface.co/docs/trl/en/dataset_formats#vision-datasets) for more information on how it should look like. A good example is [LLaVA Instruct Mix](https://huggingface.co/datasets/trl-lib/llava-instruct-mix).
 
-We also have a [`sft_vlm.py`](https://github.com/huggingface/trl/blob/main/examples/sft_visual_chat/sft_vlm.py) script that works out of the box for transformers vision language models. 
+We also have a [`sft_vlm.py`](https://github.com/huggingface/trl/blob/main/examples/sft_visual_chat/sft_visual_chat.py) script that works out of the box for transformers vision language models. 
 
 ## vLLM Integration in TRL
 
 vLLM is integrated in TRL to support online alignment methods where you need to generate samples during training. Running the example scripts like the following enables vLLM: 
 
 ```bash
-CUDA_VISIBLE_DEVICES=1,2 python3 examples/grpo_visual_math/grpo_vlm.py --model_name_or_path Qwen/Qwen2.5-VL-3B-Instruct --use_vllm --vllm_mode colocate
+CUDA_VISIBLE_DEVICES=1,2 python3 examples/grpo_visual_math/grpo_visual_math.py --model_name_or_path Qwen/Qwen2.5-VL-3B-Instruct --use_vllm --vllm_mode colocate
 ```
 
 There’s mainly two modes: `colocate` and `server`. [`colocate`](https://huggingface.co/blog/vllm-colocate) runs vLLM in the same process as the training loop, sharing the same GPU between training and generation, creating a vLLM LLM instance inside the `GRPOTrainer`. Meanwhile `server` requires you to serve vLLM separately in a different process where you can hit the server. You can start this server with the command:
@@ -275,7 +275,7 @@ trl vllm-serve --model Qwen/Qwen2.5-VL-3B-Instruct --tensor-parallel-size 1
 Then you can run the script as follows.
 
 ```bash
-CUDA_VISIBLE_DEVICES=1,2 python3 examples/grpo_visual_math/grpo_vlm.py --model_name_or_path Qwen/Qwen2.5-VL-3B-Instruct --use_vllm --vllm_mode server
+CUDA_VISIBLE_DEVICES=1,2 python3 examples/grpo_visual_math/grpo_visual_math.py --model_name_or_path Qwen/Qwen2.5-VL-3B-Instruct --use_vllm --vllm_mode server
 ```
 
 One more tip: we have added support for using vLLM with transformers backend in TRL. You can enable it when running a script with colocate or when serving the model by passing the `--vllm_model_impl transformers` flag.

--- a/trl-vlm-alignment.md
+++ b/trl-vlm-alignment.md
@@ -202,7 +202,7 @@ In addition to MPO, GRPO, and GSPO, TRL now supports [Reinforce Leave One Out](h
 
 #### Reinforce Leave One Out (RLOO)
 
-RLOO now supports common VLMs. You can find a complete training example in the [`rloo_vlm.py`](https://github.com/huggingface/trl/blob/main/examples/rloo_visual_math/rloo_visual_math.py) script.
+RLOO now supports common VLMs. You can find a complete training example in the [`rloo_visual_math.py`](https://github.com/huggingface/trl/blob/main/examples/rloo_visual_math/rloo_visual_math.py) script.
 
 Here’s how to set up a `RLOOTrainer`:
 
@@ -226,7 +226,7 @@ CUDA_VISIBLE_DEVICES=1,2 python3 examples/rloo_visual_math/rloo_visual_math.py -
 
 #### Online Direct Preference Optimization (Online DPO)
 
-Online DPO also supports VLMs. See the [`online_dpo_vlm.py`](https://github.com/huggingface/trl/blob/main/examples/online_dpo_visual_math/online_dpo_visual_math.py) script for a simple example.
+Online DPO also supports VLMs. See the [`online_dpo_visual_math.py`](https://github.com/huggingface/trl/blob/main/examples/online_dpo_visual_math/online_dpo_visual_math.py) script for a simple example.
 
 To run the example script (vLLM integration will be discussed later):
 
@@ -256,7 +256,7 @@ trainer.train()
 
 To train a VLM, you need to provide a dataset with an additional `images` column containing the images to be processed. You can take a look at [Dataset Formats — Vision Datasets](https://huggingface.co/docs/trl/en/dataset_formats#vision-datasets) for more information on how it should look like. A good example is [LLaVA Instruct Mix](https://huggingface.co/datasets/trl-lib/llava-instruct-mix).
 
-We also have a [`sft_vlm.py`](https://github.com/huggingface/trl/blob/main/examples/sft_visual_chat/sft_visual_chat.py) script that works out of the box for transformers vision language models. 
+We also have a [`sft_visual_chat.py`](https://github.com/huggingface/trl/blob/main/examples/sft_visual_chat/sft_visual_chat.py) script that works out of the box for transformers vision language models. 
 
 ## vLLM Integration in TRL
 

--- a/trl-vlm-alignment.md
+++ b/trl-vlm-alignment.md
@@ -202,7 +202,7 @@ In addition to MPO, GRPO, and GSPO, TRL now supports [Reinforce Leave One Out](h
 
 #### Reinforce Leave One Out (RLOO)
 
-RLOO now supports common VLMs. You can find a complete training example in the [`rloo_vlm.py`](https://github.com/huggingface/trl/blob/main/examples/scripts/rloo_vlm.py) script.
+RLOO now supports common VLMs. You can find a complete training example in the [`rloo_vlm.py`](https://github.com/huggingface/trl/blob/main/examples/rloo_visual_math/rloo_vlm.py) script.
 
 Here’s how to set up a `RLOOTrainer`:
 
@@ -221,17 +221,17 @@ trainer.train()
 And to launch training directly from the example script:
 
 ```bash
-CUDA_VISIBLE_DEVICES=1,2 python3 examples/scripts/rloo_vlm.py --model_name_or_path Qwen/Qwen2.5-VL-3B-Instruct
+CUDA_VISIBLE_DEVICES=1,2 python3 examples/rloo_visual_math/rloo_vlm.py --model_name_or_path Qwen/Qwen2.5-VL-3B-Instruct
 ```
 
 #### Online Direct Preference Optimization (Online DPO)
 
-Online DPO also supports VLMs. See the [`online_dpo_vlm.py`](https://github.com/huggingface/trl/blob/main/examples/scripts/online_dpo_vlm.py) script for a simple example.
+Online DPO also supports VLMs. See the [`online_dpo_vlm.py`](https://github.com/huggingface/trl/blob/main/examples/online_dpo_visual_math/online_dpo_vlm.py) script for a simple example.
 
 To run the example script (vLLM integration will be discussed later):
 
 ```bash
-CUDA_VISIBLE_DEVICES=1,2 python3 examples/scripts/online_dpo_vlm.py --model_name_or_path Qwen/Qwen2.5-VL-3B-Instruct --use_vllm --vllm_mode server
+CUDA_VISIBLE_DEVICES=1,2 python3 examples/online_dpo_visual_math/online_dpo_vlm.py --model_name_or_path Qwen/Qwen2.5-VL-3B-Instruct --use_vllm --vllm_mode server
 ```
 
 > [!NOTE]
@@ -256,14 +256,14 @@ trainer.train()
 
 To train a VLM, you need to provide a dataset with an additional `images` column containing the images to be processed. You can take a look at [Dataset Formats — Vision Datasets](https://huggingface.co/docs/trl/en/dataset_formats#vision-datasets) for more information on how it should look like. A good example is [LLaVA Instruct Mix](https://huggingface.co/datasets/trl-lib/llava-instruct-mix).
 
-We also have a [`sft_vlm.py`](https://github.com/huggingface/trl/blob/main/examples/scripts/sft_vlm.py) script that works out of the box for transformers vision language models. 
+We also have a [`sft_vlm.py`](https://github.com/huggingface/trl/blob/main/examples/sft_visual_chat/sft_vlm.py) script that works out of the box for transformers vision language models. 
 
 ## vLLM Integration in TRL
 
 vLLM is integrated in TRL to support online alignment methods where you need to generate samples during training. Running the example scripts like the following enables vLLM: 
 
 ```bash
-CUDA_VISIBLE_DEVICES=1,2 python3 examples/scripts/grpo_vlm.py --model_name_or_path Qwen/Qwen2.5-VL-3B-Instruct --use_vllm --vllm_mode colocate
+CUDA_VISIBLE_DEVICES=1,2 python3 examples/grpo_visual_math/grpo_vlm.py --model_name_or_path Qwen/Qwen2.5-VL-3B-Instruct --use_vllm --vllm_mode colocate
 ```
 
 There’s mainly two modes: `colocate` and `server`. [`colocate`](https://huggingface.co/blog/vllm-colocate) runs vLLM in the same process as the training loop, sharing the same GPU between training and generation, creating a vLLM LLM instance inside the `GRPOTrainer`. Meanwhile `server` requires you to serve vLLM separately in a different process where you can hit the server. You can start this server with the command:
@@ -275,7 +275,7 @@ trl vllm-serve --model Qwen/Qwen2.5-VL-3B-Instruct --tensor-parallel-size 1
 Then you can run the script as follows.
 
 ```bash
-CUDA_VISIBLE_DEVICES=1,2 python3 examples/scripts/grpo_vlm.py --model_name_or_path Qwen/Qwen2.5-VL-3B-Instruct --use_vllm --vllm_mode server
+CUDA_VISIBLE_DEVICES=1,2 python3 examples/grpo_visual_math/grpo_vlm.py --model_name_or_path Qwen/Qwen2.5-VL-3B-Instruct --use_vllm --vllm_mode server
 ```
 
 One more tip: we have added support for using vLLM with transformers backend in TRL. You can enable it when running a script with colocate or when serving the model by passing the `--vllm_model_impl transformers` flag.
@@ -294,6 +294,6 @@ Below, you can find a compilation of resources to explore the alignment of VLMs 
 - [**MPO VLM recipe**](https://huggingface.co/learn/cookbook/fine_tuning_vlm_mpo)
 - [**GRPO VLM recipe**](https://huggingface.co/learn/cookbook/fine_tuning_vlm_grpo_trl)
 - [**More multimodal alignment recipes**](https://huggingface.co/learn/cookbook/index)
-- [**TRL multimodal training scripts**](https://github.com/huggingface/trl/tree/main/examples/scripts)
+- [**TRL multimodal training scripts**](https://github.com/huggingface/trl/tree/main/examples)
 - [**vLLM Integration in trl docs**](https://huggingface.co/docs/trl/en/vllm_integration)
 - [**Transformers backend integration in vLLM**](https://blog.vllm.ai/2025/04/11/transformers-backend.html)

--- a/vlms.md
+++ b/vlms.md
@@ -147,7 +147,7 @@ We are excited to announce that [TRL](https://github.com/huggingface/trl)’s `S
 The dataset contains user-assistant interactions formatted as a sequence of messages. For example, each conversation is paired with an image that the user asks questions about.
 
 To use the experimental VLM training support, you must install the latest version of TRL, with `pip install -U trl`.
-The full example script can be found [here](https://github.com/huggingface/trl/blob/main/examples/sft_visual_chat/sft_vlm.py).
+The full example script can be found [here](https://github.com/huggingface/trl/blob/main/examples/sft_visual_chat/sft_visual_chat.py).
 
 ```python
 from trl.commands.cli_utils import SftScriptArguments, TrlParser

--- a/vlms.md
+++ b/vlms.md
@@ -147,7 +147,7 @@ We are excited to announce that [TRL](https://github.com/huggingface/trl)’s `S
 The dataset contains user-assistant interactions formatted as a sequence of messages. For example, each conversation is paired with an image that the user asks questions about.
 
 To use the experimental VLM training support, you must install the latest version of TRL, with `pip install -U trl`.
-The full example script can be found [here](https://github.com/huggingface/trl/blob/main/examples/scripts/vsft_llava.py).
+The full example script can be found [here](https://github.com/huggingface/trl/blob/main/examples/sft_visual_chat/sft_vlm.py).
 
 ```python
 from trl.commands.cli_utils import SftScriptArguments, TrlParser

--- a/zh/dpo_vlm.md
+++ b/zh/dpo_vlm.md
@@ -354,10 +354,10 @@ print(response_text)
 
 ## 微调 Llava 1.5 和 PaliGemma 等模型
 
-截至本文完稿时，TRL 的 DPO 实现已支持 Idefics2、Llava 1.5 和 PaliGemma，同时 TRL 也在努力支持更多的模型。最简单的调用方法还是使用 TRL 提供的 [示例脚本](https://github.com/huggingface/trl/blob/main/examples/dpo_reduce_hallucinations/dpo_vlm.py)。例如，如果你想微调 PaliGemma，你可以这样:
+截至本文完稿时，TRL 的 DPO 实现已支持 Idefics2、Llava 1.5 和 PaliGemma，同时 TRL 也在努力支持更多的模型。最简单的调用方法还是使用 TRL 提供的 [示例脚本](https://github.com/huggingface/trl/blob/main/examples/dpo_reduce_hallucinations/dpo_reduce_hallucinations.py)。例如，如果你想微调 PaliGemma，你可以这样:
 
 ```sh
-accelerate launch examples/dpo_reduce_hallucinations/dpo_vlm.py \
+accelerate launch examples/dpo_reduce_hallucinations/dpo_reduce_hallucinations.py \
     --dataset_name HuggingFaceH4/rlaif-v_formatted \
     --model_name_or_path google/paligemma-3b-pt-224 \
     --per_device_train_batch_size 2 \

--- a/zh/dpo_vlm.md
+++ b/zh/dpo_vlm.md
@@ -354,10 +354,10 @@ print(response_text)
 
 ## 微调 Llava 1.5 和 PaliGemma 等模型
 
-截至本文完稿时，TRL 的 DPO 实现已支持 Idefics2、Llava 1.5 和 PaliGemma，同时 TRL 也在努力支持更多的模型。最简单的调用方法还是使用 TRL 提供的 [示例脚本](https://github.com/huggingface/trl/blob/main/examples/scripts/dpo_visual.py)。例如，如果你想微调 PaliGemma，你可以这样:
+截至本文完稿时，TRL 的 DPO 实现已支持 Idefics2、Llava 1.5 和 PaliGemma，同时 TRL 也在努力支持更多的模型。最简单的调用方法还是使用 TRL 提供的 [示例脚本](https://github.com/huggingface/trl/blob/main/examples/dpo_reduce_hallucinations/dpo_vlm.py)。例如，如果你想微调 PaliGemma，你可以这样:
 
 ```sh
-accelerate launch examples/scripts/dpo_visual.py \
+accelerate launch examples/dpo_reduce_hallucinations/dpo_vlm.py \
     --dataset_name HuggingFaceH4/rlaif-v_formatted \
     --model_name_or_path google/paligemma-3b-pt-224 \
     --per_device_train_batch_size 2 \

--- a/zh/gemma.md
+++ b/zh/gemma.md
@@ -238,7 +238,7 @@ for message in chat_completion:
 
 一个微调 Gemma 的示例命令如下。我们利用 4 位量化和 QLoRA（一种参数效率微调技术）来减少内存使用，目标是所有注意力块的线性层。值得注意的是，与密集型 Transformer 不同，MLP 层（多层感知器层）因其稀疏性不适合与 PEFT（参数效率微调）技术结合使用。
 
-首先，安装 🤗 TRL 的最新版本并克隆仓库以获取 [训练脚本](https://github.com/huggingface/trl/blob/main/examples/scripts/sft.py)：
+首先，安装 🤗 TRL 的最新版本并克隆仓库以获取 [训练脚本](https://github.com/huggingface/trl/blob/main/trl/scripts/sft.py)：
 
 ```jsx
 pip install -U transformers trl peft bitsandbytes
@@ -250,7 +250,7 @@ cd trl
 
 ```jsx
 accelerate launch --config_file examples/accelerate_configs/multi_gpu.yaml --num_processes=1 \
-    examples/scripts/sft.py \
+    trl/scripts/sft.py \
     --model_name google/gemma-7b \
     --dataset_name OpenAssistant/oasst_top1_2023-08-25 \
     --per_device_train_batch_size 2 \

--- a/zh/gemma2.md
+++ b/zh/gemma2.md
@@ -222,7 +222,7 @@ pipeline = pipeline(
 
 下面是在 OpenAssistant 的[聊天数据集](https://huggingface.co/datasets/OpenAssistant/oasst_top1_2023-08-25)上微调 Gemma 的示例命令。我们使用 4 位量化和 [QLoRA](https://arxiv.org/abs/2305.14314) 来节省内存,以针对所有注意力块的线性层。请注意,与密集变换器不同,不应针对 MLP 层,因为它们是稀疏的,与 PEFT 不太兼容。
 
-首先,安装 🤗 TRL 的每日版本并克隆仓库以访问[训练脚本](https://github.com/huggingface/trl/blob/main/examples/scripts/sft.py):
+首先,安装 🤗 TRL 的每日版本并克隆仓库以访问[训练脚本](https://github.com/huggingface/trl/blob/main/trl/scripts/sft.py):
 
 ```jsx
 pip install "transformers>=4.42.3" --upgrade
@@ -238,7 +238,7 @@ cd trl
 ```bash
 # peft 调优;单 GPU;https://wandb.ai/costa-huang/huggingface/runs/l1l53cst
 python \
-	examples/scripts/sft.py \
+	trl/scripts/sft.py \
 	--model_name google/gemma-2-27b \
 	--dataset_name OpenAssistant/oasst_top1_2023-08-25 \
 	--dataset_text_field="text" \
@@ -268,7 +268,7 @@ python \
 
 ```bash
 accelerate launch --config_file=examples/accelerate_configs/deepspeed_zero3.yaml \
-	examples/scripts/sft.py \
+	trl/scripts/sft.py \
 	--model_name google/gemma-2-27b \
 	--dataset_name OpenAssistant/oasst_top1_2023-08-25 \
 	--dataset_text_field="text" \

--- a/zh/llama31.md
+++ b/zh/llama31.md
@@ -696,7 +696,7 @@ _注意: 我们目前正在与我们的合作伙伴 AWS、Google Cloud、Microso
 <details close>
 <summary>使用 Hugging Face TRL 的微调示例</summary>
 
-首先，安装最新版本的 🤗 TRL 并克隆 repo 以访问 [训练脚本](https://github.com/huggingface/trl/blob/main/examples/scripts/sft.py):
+首先，安装最新版本的 🤗 TRL 并克隆 repo 以访问 [训练脚本](https://github.com/huggingface/trl/blob/main/trl/scripts/sft.py):
 
 ```
 pip install "transformers>=4.43" --upgrade
@@ -711,7 +711,7 @@ cd trl
 
 ```
 python \
-    examples/scripts/sft.py \
+    trl/scripts/sft.py \
     --model_name meta-llama/Meta-Llama-3.1-8B \
     --dataset_name OpenAssistant/oasst_top1_2023-08-25 \
     --dataset_text_field="text" \
@@ -736,7 +736,7 @@ python \
 
 ```
 accelerate launch --config_file=examples/accelerate_configs/deepspeed_zero3.yaml \
-    examples/scripts/sft.py \
+    trl/scripts/sft.py \
     --model_name meta-llama/Meta-Llama-3.1-8B \
     --dataset_name OpenAssistant/oasst_top1_2023-08-25 \
     --dataset_text_field="text" \

--- a/zh/llama32.md
+++ b/zh/llama32.md
@@ -29,7 +29,7 @@ Llama 3.2 还包括可以在设备上运行的小型仅文本语言模型。它�
 - [Hub 上的模型检查点](https://huggingface.co/collections/meta-llama/llama-32-66f448ffc8c32f949b04c8cf)
 - Hugging Face Transformers 和 TGI 对视觉模型的集成
 - 在 Google Cloud、Amazon SageMaker 和 DELL 企业中心的推理与部署集成
-- 使用 [transformers🤗](https://github.com/huggingface/huggingface-llama-recipes/tree/main/Llama-Vision%20FT.ipynb) 和 [TRL](https://github.com/huggingface/trl/tree/main/examples/scripts/sft_vlm.py) 在单个 GPU 上微调 Llama 3.2 11B 视觉模型
+- 使用 [transformers🤗](https://github.com/huggingface/huggingface-llama-recipes/tree/main/Llama-Vision%20FT.ipynb) 和 [TRL](https://github.com/huggingface/trl/tree/main/examples/sft_visual_chat/sft_vlm.py) 在单个 GPU 上微调 Llama 3.2 11B 视觉模型
 
 ## 目录
 
@@ -415,12 +415,12 @@ trl sft --model_name_or_path meta-llama/Llama-3.2-3B \
          --gradient_checkpointing
 ```
 
-TRL 还支持使用 [这个脚本](https://github.com/huggingface/trl/tree/main/examples/scripts/sft_vlm.py) 微调 Llama 3.2 Vision。
+TRL 还支持使用 [这个脚本](https://github.com/huggingface/trl/tree/main/examples/sft_visual_chat/sft_vlm.py) 微调 Llama 3.2 Vision。
 
 ```bash
 # Tested on 8x H100 GPUs
 accelerate launch --config_file=examples/accelerate_configs/deepspeed_zero3.yaml \
-    examples/scripts/sft_vlm.py \
+    examples/sft_visual_chat/sft_vlm.py \
     --dataset_name HuggingFaceH4/llava-instruct-mix-vsft \
     --model_name_or_path meta-llama/Llama-3.2-11B-Vision-Instruct \
     --per_device_train_batch_size 8 \

--- a/zh/llama32.md
+++ b/zh/llama32.md
@@ -29,7 +29,7 @@ Llama 3.2 还包括可以在设备上运行的小型仅文本语言模型。它�
 - [Hub 上的模型检查点](https://huggingface.co/collections/meta-llama/llama-32-66f448ffc8c32f949b04c8cf)
 - Hugging Face Transformers 和 TGI 对视觉模型的集成
 - 在 Google Cloud、Amazon SageMaker 和 DELL 企业中心的推理与部署集成
-- 使用 [transformers🤗](https://github.com/huggingface/huggingface-llama-recipes/tree/main/Llama-Vision%20FT.ipynb) 和 [TRL](https://github.com/huggingface/trl/tree/main/examples/sft_visual_chat/sft_vlm.py) 在单个 GPU 上微调 Llama 3.2 11B 视觉模型
+- 使用 [transformers🤗](https://github.com/huggingface/huggingface-llama-recipes/tree/main/Llama-Vision%20FT.ipynb) 和 [TRL](https://github.com/huggingface/trl/tree/main/examples/sft_visual_chat/sft_visual_chat.py) 在单个 GPU 上微调 Llama 3.2 11B 视觉模型
 
 ## 目录
 
@@ -415,12 +415,12 @@ trl sft --model_name_or_path meta-llama/Llama-3.2-3B \
          --gradient_checkpointing
 ```
 
-TRL 还支持使用 [这个脚本](https://github.com/huggingface/trl/tree/main/examples/sft_visual_chat/sft_vlm.py) 微调 Llama 3.2 Vision。
+TRL 还支持使用 [这个脚本](https://github.com/huggingface/trl/tree/main/examples/sft_visual_chat/sft_visual_chat.py) 微调 Llama 3.2 Vision。
 
 ```bash
 # Tested on 8x H100 GPUs
 accelerate launch --config_file=examples/accelerate_configs/deepspeed_zero3.yaml \
-    examples/sft_visual_chat/sft_vlm.py \
+    examples/sft_visual_chat/sft_visual_chat.py \
     --dataset_name HuggingFaceH4/llava-instruct-mix-vsft \
     --model_name_or_path meta-llama/Llama-3.2-11B-Vision-Instruct \
     --per_device_train_batch_size 8 \

--- a/zh/mixtral.md
+++ b/zh/mixtral.md
@@ -195,7 +195,7 @@ docker run --gpus all --shm-size 1g -p 3000:80 -v /data:/data ghcr.io/huggingfac
 
 下面是在 OpenAssistant 的 [聊天数据集](https://huggingface.co/datasets/OpenAssistant/oasst_top1_2023-08-25) 上微调 Mixtral 的示例命令。为了节省内存，我们对注意力块中的所有线性层执行 4 比特量化和 [QLoRA](https://arxiv.org/abs/2305.14314)。请注意，与稠密 transformer 模型不同，我们不对专家网络中的 MLP 层进行量化，因为它们很稀疏并且量化后 PEFT 效果不好。
 
-首先，安装 🤗 TRL 的每日构建版并下载代码库以获取 [训练脚本](https://github.com/huggingface/trl/blob/main/examples/scripts/sft.py):
+首先，安装 🤗 TRL 的每日构建版并下载代码库以获取 [训练脚本](https://github.com/huggingface/trl/blob/main/trl/scripts/sft.py):
 
 ```bash
 pip install -U transformers
@@ -208,7 +208,7 @@ cd trl
 
 ```bash
 accelerate launch --config_file examples/accelerate_configs/multi_gpu.yaml --num_processes=1 \
-	examples/scripts/sft.py \
+	trl/scripts/sft.py \
 	--model_name mistralai/Mixtral-8x7B-v0.1 \
 	--dataset_name trl-lib/ultrachat_200k_chatml \
 	--batch_size 2 \

--- a/zh/trl-ddpo.md
+++ b/zh/trl-ddpo.md
@@ -101,7 +101,7 @@ pip install wandb torchvision
 
 ### 演练一遍
 
-`trl` 库中负责 DDPO 训练的主要是 `DDPOTrainer` 和 `DDPOConfig` 这两个类。有关 `DDPOTrainer` 和 `DDPOConfig` 的更多信息，请参阅 [相应文档](https://huggingface.co/docs/trl/ddpo_trainer#getting-started-with-examplesscriptsstablediffusiontuningpy)。 `trl` 代码库中有一个 [示例训练脚本](https://github.com/huggingface/trl/blob/main/examples/scripts/stable_diffusion_tuning.py)。它默认使用这两个类，并有一套默认的输入和参数用于微调 `RunwayML` 中的预训练 Stable Diffusion 模型。
+`trl` 库中负责 DDPO 训练的主要是 `DDPOTrainer` 和 `DDPOConfig` 这两个类。有关 `DDPOTrainer` 和 `DDPOConfig` 的更多信息，请参阅 [相应文档](https://huggingface.co/docs/trl/ddpo_trainer#getting-started-with-examplesscriptsstablediffusiontuningpy)。 `trl` 代码库中有一个 [示例训练脚本](https://github.com/huggingface/trl/blob/v0.9.6/examples/scripts/ddpo.py)。它默认使用这两个类，并有一套默认的输入和参数用于微调 `RunwayML` 中的预训练 Stable Diffusion 模型。
 
 此示例脚本使用 `wandb` 记录训练日志，并使用美学奖励模型，其权重是从公开的 Hugging Face 存储库读取的 (因此数据收集和美学奖励模型训练均已经帮你做完了)。默认提示数据是一系列动物名。
 

--- a/zh/vlms.md
+++ b/zh/vlms.md
@@ -150,7 +150,7 @@ print(processor.decode(output[0], skip_special_tokens=True))
 
 `llava-instruct` 数据集将用户与助理之间的交互组织成消息序列的格式，且每个消息序列皆与用户问题所指的图像配对。
 
-要用上 VLM 训练的功能，你必须使用 `pip install -U trl` 安装最新版本的 TRL。你可在 [此处](https://github.com/huggingface/trl/blob/main/examples/scripts/vsft_llava.py) 找到完整的示例脚本。
+要用上 VLM 训练的功能，你必须使用 `pip install -U trl` 安装最新版本的 TRL。你可在 [此处](https://github.com/huggingface/trl/blob/main/examples/sft_visual_chat/sft_vlm.py) 找到完整的示例脚本。
 
 ```python
 from trl.commands.cli_utils import SftScriptArguments, TrlParser

--- a/zh/vlms.md
+++ b/zh/vlms.md
@@ -150,7 +150,7 @@ print(processor.decode(output[0], skip_special_tokens=True))
 
 `llava-instruct` 数据集将用户与助理之间的交互组织成消息序列的格式，且每个消息序列皆与用户问题所指的图像配对。
 
-要用上 VLM 训练的功能，你必须使用 `pip install -U trl` 安装最新版本的 TRL。你可在 [此处](https://github.com/huggingface/trl/blob/main/examples/sft_visual_chat/sft_vlm.py) 找到完整的示例脚本。
+要用上 VLM 训练的功能，你必须使用 `pip install -U trl` 安装最新版本的 TRL。你可在 [此处](https://github.com/huggingface/trl/blob/main/examples/sft_visual_chat/sft_visual_chat.py) 找到完整的示例脚本。
 
 ```python
 from trl.commands.cli_utils import SftScriptArguments, TrlParser


### PR DESCRIPTION
Follow-up to huggingface/trl#6820: TRL's `examples/` was reorganized into self-contained per-example folders, so links to the old `examples/scripts/...` paths will 404 once it merges. This updates them to the new locations.